### PR TITLE
[DDCI-115] - added temporal date fields

### DIFF
--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -8,8 +8,15 @@ from ckanext.qdes_schema import helpers
 class QDESSchemaPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IValidators)
 
     # IConfigurer
+
+    # IValidators
+    def get_validators(self):
+        return {
+            'qdes_temporal_start_end_date': self.qdes_temporal_start_end_date
+        }
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
@@ -24,3 +31,8 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
 
     def get_multi_textarea_values(self, value):
         return json.loads(value) if value else ['']
+
+    def qdes_temporal_start_end_date(self, field, value):
+        if len(value) > 300:
+            raise Invalid("Max chars should be 3 characters")
+        return value

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -2,7 +2,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import json
 
-from ckanext.qdes_schema import helpers
+from ckanext.qdes_schema import helpers, validators
 
 
 class QDESSchemaPlugin(plugins.SingletonPlugin):
@@ -15,7 +15,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     # IValidators
     def get_validators(self):
         return {
-            'qdes_temporal_start_end_date': self.qdes_temporal_start_end_date
+            'qdes_temporal_start_end_date': validators.qdes_temporal_start_end_date
         }
 
     def update_config(self, config_):
@@ -31,8 +31,3 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
 
     def get_multi_textarea_values(self, value):
         return json.loads(value) if value else ['']
-
-    def qdes_temporal_start_end_date(self, field, value):
-        if len(value) > 300:
-            raise Invalid("Max chars should be 3 characters")
-        return value

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -93,16 +93,19 @@
       "field_name": "temporal_start",
       "label": "Start",
       "display_property": "dcat:startDate",
+      "preset": "date",
+      "validators": "qdes_temporal_start_end_date",
       "display_group": "temporal content",
-      "preset": "date"
+      "sub_heading": "temporal coverage"
     },
     {
       "field_name": "temporal_end",
       "label": "End",
       "display_property": "dcat:endDate",
-      "display_group": "temporal content",
       "preset": "date",
-      "validators": "qdes_temporal_start_end_date"
+      "validators": "qdes_temporal_start_end_date",
+      "display_group": "temporal content",
+      "sub_heading": "temporal coverage"
     },
     {
       "field_name": "tag_string",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -91,7 +91,7 @@
     },
     {
       "field_name": "temporal_start",
-      "label": "Start",
+      "label": "Temporal coverage start",
       "display_property": "dcat:startDate",
       "preset": "date",
       "validators": "qdes_temporal_start_end_date",
@@ -100,7 +100,7 @@
     },
     {
       "field_name": "temporal_end",
-      "label": "End",
+      "label": "Temporal coverage end",
       "display_property": "dcat:endDate",
       "preset": "date",
       "validators": "qdes_temporal_start_end_date",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -90,6 +90,21 @@
       "display_group": "description"
     },
     {
+      "field_name": "temporal_start",
+      "label": "Start",
+      "display_property": "dcat:startDate",
+      "display_group": "temporal content",
+      "preset": "date"
+    },
+    {
+      "field_name": "temporal_end",
+      "label": "End",
+      "display_property": "dcat:endDate",
+      "display_group": "temporal content",
+      "preset": "date",
+      "validators": "qdes_temporal_start_end_date"
+    },
+    {
       "field_name": "tag_string",
       "label": "Tags",
       "preset": "tag_string_autocomplete",

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/additional_info.html
@@ -1,0 +1,43 @@
+{% extends "package/snippets/additional_info.html" %}
+
+{%- set exclude_fields = [
+    'id',
+    'title',
+    'name',
+    'notes',
+    'tag_string',
+    'license_id',
+    'owner_org',
+    ] -%}
+
+{%- set temporal_coverage = [
+    'temporal_start',
+    'temporal_end',
+    ] -%}
+
+{% block package_additional_info %}
+  {%- for field in schema.dataset_fields -%}
+    {%- if field.field_name not in exclude_fields
+        and field.display_snippet is not none -%}
+      <tr>
+        <th scope="row" class="dataset-label">
+            {% if field.field_name in temporal_coverage %}
+                {{ "Temporal coverage start" if field.field_name == 'temporal_start' else "Temporal coverage end" }}
+            {%- else -%}
+                {{ h.scheming_language_text(field.label) }}
+            {%- endif -%}
+        </th>
+        <td class="dataset-details"{%
+          if field.display_property %} property="{{ field.display_property
+          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
+          field=field, data=pkg_dict, schema=schema -%}</td>
+      </tr>
+    {%- endif -%}
+  {%- endfor -%}
+  {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+    <tr>
+      <th scope="row" class="dataset-label">{{ _("State") }}</th>
+      <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+    </tr>
+  {% endif %}
+{% endblock %}

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
@@ -30,6 +30,12 @@
             <h2>{{ field.display_group|capitalize }}</h2>
         {%- endif -%}
     {%- endif -%}
+
+    {%- if field.sub_heading is not none and field.sub_heading != ns.sub_heading -%}
+        {%- set ns.sub_heading = field.sub_heading -%}
+        <h3>{{ field.sub_heading|capitalize }}</h3>
+    {%- endif -%}
+
     {%- if field.form_snippet is not none -%}
       {%- snippet 'scheming/snippets/form_field.html',
         field=field, data=data, errors=errors, licenses=c.licenses,

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -1,0 +1,7 @@
+import ckan.plugins.toolkit as toolkit
+
+
+def qdes_temporal_start_end_date(field, schema):
+    if len(field) > 300:
+        raise toolkit.Invalid("Max chars should be 3 characters")
+    return field

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -18,6 +18,6 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
     if (len(temporal_start_value) > 0) and (len(temporal_end_value) > 0):
         if dt.strptime(temporal_start_value, '%Y-%m-%d') > dt.strptime(temporal_end_value, '%Y-%m-%d'):
             if key == ('temporal_start',):
-                raise toolkit.Invalid("Start date must be less then end date.")
+                raise toolkit.Invalid("Must be earlier than end date.")
             elif key == ('temporal_end',):
-                raise toolkit.Invalid("End date must be higher then start date.")
+                raise toolkit.Invalid("Must be later than start date.")

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -1,4 +1,5 @@
 import ckan.plugins.toolkit as toolkit
+from datetime import datetime as dt
 
 def qdes_temporal_start_end_date(key, flattened_data, errors, context):
     temporal_start_value = flattened_data[('temporal_start',)]
@@ -6,3 +7,10 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
 
     if ((len(temporal_start_value) > 0) != (len(temporal_end_value) > 0)) and (len(flattened_data.get(key)) == 0):
         raise toolkit.Invalid("This field should not be empty")
+
+
+    if dt.strptime(temporal_start_value, '%Y-%m-%d') > dt.strptime(temporal_end_value, '%Y-%m-%d'):
+        if key == ('temporal_start',):
+            raise toolkit.Invalid("Start date must be less then end date.")
+        elif key == ('temporal_end',):
+            raise toolkit.Invalid("End date must be higher then start date.")

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -1,7 +1,8 @@
 import ckan.plugins.toolkit as toolkit
 
+def qdes_temporal_start_end_date(key, flattened_data, errors, context):
+    temporal_start_value = flattened_data[('temporal_start',)]
+    temporal_end_value = flattened_data[('temporal_end',)]
 
-def qdes_temporal_start_end_date(field, schema):
-    if len(field) > 300:
-        raise toolkit.Invalid("Max chars should be 3 characters")
-    return field
+    if ((len(temporal_start_value) > 0) != (len(temporal_end_value) > 0)) and (len(flattened_data.get(key)) == 0):
+        raise toolkit.Invalid("This field should not be empty")

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -2,15 +2,22 @@ import ckan.plugins.toolkit as toolkit
 from datetime import datetime as dt
 
 def qdes_temporal_start_end_date(key, flattened_data, errors, context):
+    """
+    Validate the start and date.
+
+    It will raise an error, when:
+    - If the either start or end date is not empty.
+    - If the start date < end date
+    """
     temporal_start_value = flattened_data[('temporal_start',)]
     temporal_end_value = flattened_data[('temporal_end',)]
 
     if ((len(temporal_start_value) > 0) != (len(temporal_end_value) > 0)) and (len(flattened_data.get(key)) == 0):
         raise toolkit.Invalid("This field should not be empty")
 
-
-    if dt.strptime(temporal_start_value, '%Y-%m-%d') > dt.strptime(temporal_end_value, '%Y-%m-%d'):
-        if key == ('temporal_start',):
-            raise toolkit.Invalid("Start date must be less then end date.")
-        elif key == ('temporal_end',):
-            raise toolkit.Invalid("End date must be higher then start date.")
+    if (len(temporal_start_value) > 0) and (len(temporal_end_value) > 0):
+        if dt.strptime(temporal_start_value, '%Y-%m-%d') > dt.strptime(temporal_end_value, '%Y-%m-%d'):
+            if key == ('temporal_start',):
+                raise toolkit.Invalid("Start date must be less then end date.")
+            elif key == ('temporal_end',):
+                raise toolkit.Invalid("End date must be higher then start date.")


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-115

- it will throw an error when one of the values is empty.
- if both values are empty or filled, it won't throw an error
- if start < end date, it will throw an error.
- added subheading
- modify the output to include subheading on the field label

![image](https://user-images.githubusercontent.com/1538818/91256591-e961db00-e791-11ea-8222-d1fa7d4128cb.png)

![image](https://user-images.githubusercontent.com/1538818/91256627-05fe1300-e792-11ea-8900-84db8dbf607c.png)

![image](https://user-images.githubusercontent.com/1538818/91256640-12826b80-e792-11ea-88a8-ca42490fbc35.png)

![image](https://user-images.githubusercontent.com/1538818/91256649-17471f80-e792-11ea-9c03-e4a7dcb0fbd9.png)

![image](https://user-images.githubusercontent.com/1538818/91257325-c89a8500-e793-11ea-976c-134cf9dfe270.png)

![image](https://user-images.githubusercontent.com/1538818/91257454-1c0cd300-e794-11ea-9547-137d7b7be5db.png)

