### PR TITLE
[DDCI-119] - added creation, release and last modified fields

### DIFF
--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -4,7 +4,6 @@ import json
 
 from ckanext.qdes_schema import helpers, validators
 
-
 class QDESSchemaPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
@@ -15,7 +14,9 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     # IValidators
     def get_validators(self):
         return {
-            'qdes_temporal_start_end_date': validators.qdes_temporal_start_end_date
+            'qdes_temporal_start_end_date': validators.qdes_temporal_start_end_date,
+            'qdes_dataset_creation_date': validators.qdes_dataset_creation_date,
+            'qdes_dataset_current_date_later_than_creation': validators.qdes_dataset_current_date_later_than_creation,
         }
 
     def update_config(self, config_):

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -130,6 +130,30 @@
       "display_group": "spatial details"
     },
     {
+      "field_name": "dataset_creation_date",
+      "label": "Creation date",
+      "display_property": "dcterms:created",
+      "preset": "datetime_tz",
+      "validators": "scheming_isodatetime_tz convert_to_json_if_datetime qdes_dataset_creation_date",
+      "display_group": "status"
+    },
+    {
+      "field_name": "dataset_release_date",
+      "label": "Release date",
+      "display_property": "dcterms:issued",
+      "preset": "datetime_tz",
+      "validators": "scheming_isodatetime_tz convert_to_json_if_datetime qdes_dataset_current_date_later_than_creation",
+      "display_group": "status"
+    },
+    {
+      "field_name": "dataset_last_modified_date",
+      "label": "Last modified date",
+      "display_property": "dcterms:modified",
+      "preset": "datetime_tz",
+      "validators": "scheming_isodatetime_tz convert_to_json_if_datetime qdes_dataset_current_date_later_than_creation",
+      "display_group": "status"
+    },
+    {
       "field_name": "owner_org",
       "label": "Organization",
       "preset": "dataset_organization"

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/datetime_tz.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/datetime_tz.html
@@ -1,0 +1,66 @@
+{% import 'macros/form.html' as form %}
+{% set date = data.get(field.field_name + '_date') %}
+{% set time = data.get(field.field_name + '_time') %}
+{% set tz = data.get(field.field_name + '_tz', h.get_display_timezone().zone) %}
+
+
+{% if not date is string and not time is string %}
+    {% set date = data.get(field.field_name) %}
+
+    {% if date %}
+        {% set tz = h.get_display_timezone().zone %}
+        {% set localdate = h.scheming_datetime_to_tz(h.date_str_to_datetime(date), tz).isoformat() %}
+
+        {% set parts = localdate.split('T') %}
+        {% set date = parts[0] %}
+        {% set time = parts[1] %}
+    {% endif %}
+{% endif %}
+
+<div class="row">
+    {% call form.input(
+        field.field_name + '_date',
+        id='field-' + field.field_name +  '-date',
+        label= h.scheming_language_text(field.label),
+        type='date',
+        value=date,
+        error=errors[field.field_name],
+        classes=['control-medium', 'col-sm-4'],
+        attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+        is_required=h.scheming_field_required(field)
+        )
+    %}
+        {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+    {% endcall %}
+
+    {% call form.input(
+        field.field_name + '_time',
+        id='field-' + field.field_name + '-time',
+        label= h.scheming_language_text(field.get('label_time', 'Time')),
+        type='time',
+        value=time,
+        error=errors[field.field_name],
+        classes=['control-medium', 'col-sm-4'],
+        attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+        is_required=h.scheming_field_required(field)
+        )
+    %}
+        {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+    {% endcall %}
+
+    {% set tz_list = h.scheming_get_timezones(field) %}
+    {% call form.select(
+        field.field_name + '_tz',
+        id='field-' + field.field_name + '-tz',
+        label=h.scheming_language_text(field.get('label_tz', 'Timezone')),
+        options=tz_list,
+        selected=tz,
+        error=errors[field.field_name + '_tz'],
+        classes=['control-medium', 'col-sm-4'],
+        attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+        is_required=h.scheming_field_required(field)
+        )
+    %}
+        {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+    {% endcall %}
+</div>

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -48,4 +48,4 @@ def qdes_dataset_current_date_later_than_creation(key, flattened_data, errors, c
             dt_release = dt.strptime(current_date_value, '%Y-%m-%dT%H:%M:%S')
 
             if dt_release < dt_creation:
-                raise toolkit.Invalid("Must be later than start date.")
+                raise toolkit.Invalid("Must be later than creation date.")

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -7,7 +7,7 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
 
     It will raise an error, when:
     - If the either start or end date is not empty.
-    - If the start date < end date
+    - If the start date < end date.
     """
     temporal_start_value = flattened_data[('temporal_start',)]
     temporal_end_value = flattened_data[('temporal_end',)]
@@ -20,4 +20,32 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
             if key == ('temporal_start',):
                 raise toolkit.Invalid("Must be earlier than end date.")
             elif key == ('temporal_end',):
+                raise toolkit.Invalid("Must be later than start date.")
+
+def qdes_dataset_creation_date(value):
+    """
+    Return current datetime in UTC when value is empty.
+    """
+    if value is None:
+        return dt.utcnow().strftime('%Y-%m-%dT%H:%M')
+
+    return value
+
+def qdes_dataset_current_date_later_than_creation(key, flattened_data, errors, context):
+    """
+    Validate current date field against dataset_creation_date field.
+
+    It will raise an error, when current date value < dataset_creation_date.
+    """
+    # Get date values.
+    dataset_creation_date_value = flattened_data[('dataset_creation_date',)]
+    current_date_value = flattened_data[key]
+
+    # Need to make sure current date date >= creation date.
+    if (dataset_creation_date_value is not None) and (current_date_value is not None):
+        if len(current_date_value) > 0:
+            dt_creation = dt.strptime(dataset_creation_date_value, '%Y-%m-%dT%H:%M:%S')
+            dt_release = dt.strptime(current_date_value, '%Y-%m-%dT%H:%M:%S')
+
+            if dt_release < dt_creation:
                 raise toolkit.Invalid("Must be later than start date.")


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-119

so the date and time picker default to browser, I tested on other browsers it gives different results.
so if we want to capture down to seconds, need to implement a new time picker here, I assume another 2hrs will be enough (using default style provided by the js lib), 

maybe this simple one https://www.jonthornton.com/jquery-timepicker/ 


- if the creation date is empty, it will set by the current date-time on BE
- both release and last modified need to be >= creation date, otherwise, error raise


![image](https://user-images.githubusercontent.com/1538818/91373279-313f3b80-e840-11ea-8ad6-58cbcb3fe079.png)

![image](https://user-images.githubusercontent.com/1538818/91373204-f50bdb00-e83f-11ea-92f1-784c334dbf6c.png)
