### PR TITLE
[DDCI-118] - added spatial fields and its validation

### DIFF
--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -21,6 +21,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'qdes_validate_geojson_point': validators.qdes_validate_geojson_point,
             'qdes_validate_geojson_polygon': validators.qdes_validate_geojson_polygon,
             'qdes_within_au_bounding_box': validators.qdes_within_au_bounding_box,
+            'qdes_validate_geojson_spatial': validators.qdes_validate_geojson_spatial,
             'qdes_spatial_points_pair': validators.qdes_spatial_points_pair,
         }
 

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -9,8 +9,6 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IValidators)
 
-    # IConfigurer
-
     # IValidators
     def get_validators(self):
         return {
@@ -18,7 +16,24 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'qdes_dataset_creation_date': validators.qdes_dataset_creation_date,
             'qdes_dataset_current_date_later_than_creation': validators.qdes_dataset_current_date_later_than_creation,
             'qdes_uri_validator': validators.qdes_uri_validator,
+            'qdes_validate_decimal': validators.qdes_validate_decimal,
+            'qdes_validate_geojson': validators.qdes_validate_geojson,
+            'qdes_validate_geojson_point': validators.qdes_validate_geojson_point,
+            'qdes_validate_geojson_polygon': validators.qdes_validate_geojson_polygon,
+            'qdes_within_au_bounding_box': validators.qdes_within_au_bounding_box,
+            'qdes_spatial_points_pair': validators.qdes_spatial_points_pair,
         }
+
+    # IConfigurer
+    def update_config_schema(self, schema):
+        ignore_missing = toolkit.get_validator('ignore_missing')
+        qdes_validate_geojson = toolkit.get_validator('qdes_validate_geojson')
+
+        schema.update({
+            'ckanext.qdes_schema.au_bounding_box': [ignore_missing, qdes_validate_geojson],
+        })
+
+        return schema
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -108,6 +108,57 @@
       "sub_heading": "temporal coverage"
     },
     {
+      "field_name": "spatial_lower_left",
+      "label": "Lower left",
+      "preset": "json_object",
+      "validators": "qdes_spatial_points_pair qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "display_property": "qdcat:lowerLeft",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_upper_right",
+      "label": "Upper right",
+      "preset": "json_object",
+      "validators": "qdes_spatial_points_pair qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "display_property": "qdcat:upperRight",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_centroid",
+      "label": "Centroid",
+      "preset": "json_object",
+      "validators": "qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "display_property": "dcat:centroid",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_geometry",
+      "label": "Geometry",
+      "preset": "json_object",
+      "validators": "qdes_validate_geojson qdes_validate_geojson_polygon",
+      "display_property": "qdcat:asGeoJSON",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_content_resolution",
+      "label": "Spatial resolution in meters",
+      "validators": "qdes_validate_decimal",
+      "display_property": "dcat:spatialResolutionInMeters",
+      "display_group": "spatial content"
+    },
+    {
+      "field_name": "spatial",
+      "label": "Spatial",
+      "preset": "json_object",
+      "validators": "scheming_load_json",
+      "display_property": "dcat:spatialResolutionInMeters",
+      "display_group": "spatial content"
+    },
+    {
       "field_name": "tag_string",
       "label": "Tags",
       "preset": "tag_string_autocomplete",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -111,7 +111,7 @@
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "preset": "json_object",
-      "validators": "qdes_spatial_points_pair qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "validators": "qdes_spatial_points_pair qdes_validate_geojson_point qdes_within_au_bounding_box",
       "display_property": "qdcat:lowerLeft",
       "display_group": "spatial content",
       "sub_heading": "spatial coverage"
@@ -120,7 +120,7 @@
       "field_name": "spatial_upper_right",
       "label": "Upper right",
       "preset": "json_object",
-      "validators": "qdes_spatial_points_pair qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "validators": "qdes_spatial_points_pair qdes_validate_geojson_point qdes_within_au_bounding_box",
       "display_property": "qdcat:upperRight",
       "display_group": "spatial content",
       "sub_heading": "spatial coverage"
@@ -129,7 +129,7 @@
       "field_name": "spatial_centroid",
       "label": "Centroid",
       "preset": "json_object",
-      "validators": "qdes_validate_geojson qdes_validate_geojson_point qdes_within_au_bounding_box",
+      "validators": "qdes_validate_geojson_point qdes_within_au_bounding_box",
       "display_property": "dcat:centroid",
       "display_group": "spatial content",
       "sub_heading": "spatial coverage"
@@ -138,7 +138,7 @@
       "field_name": "spatial_geometry",
       "label": "Geometry",
       "preset": "json_object",
-      "validators": "qdes_validate_geojson qdes_validate_geojson_polygon",
+      "validators": "qdes_validate_geojson_polygon",
       "display_property": "qdcat:asGeoJSON",
       "display_group": "spatial content",
       "sub_heading": "spatial coverage"
@@ -154,8 +154,8 @@
       "field_name": "spatial",
       "label": "Spatial",
       "preset": "json_object",
-      "validators": "scheming_load_json",
-      "display_property": "dcat:spatialResolutionInMeters",
+      "form_snippet": "qdes_hidden_json.html",
+      "validators": "qdes_validate_geojson_spatial",
       "display_group": "spatial content"
     },
     {

--- a/ckanext/qdes_schema/templates/admin/config.html
+++ b/ckanext/qdes_schema/templates/admin/config.html
@@ -1,0 +1,35 @@
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block admin_form %}
+    {{ super() }}
+    {{ form.textarea(
+        'ckanext.qdes_schema.au_bounding_box',
+        id='field-ckanext.qdes_schema.au_bounding_box',
+        label=_('Australia Bounding Box'),
+        placeholder='GeoJSON polygon',
+        value=data['ckanext.qdes_schema.au_bounding_box'],
+        error=errors['ckanext.qdes_schema.au_bounding_box']) }}
+{% endblock %}
+
+{% block admin_form_help %}
+    {{ super() }}
+    <p>
+        <strong>Australia Bounding Box:</strong> Example:<br/>
+        <pre>
+{
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [100.0, 0.0],
+            [101.0, 0.0],
+            [101.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 0.0]
+        ]
+    ]
+}
+        </pre>
+    </p>
+{% endblock %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_hidden_json.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_hidden_json.html
@@ -1,0 +1,19 @@
+{% import 'macros/form.html' as form %}
+
+{% set value = data[field.field_name] %}
+{% set visibility = [] if g.debug else ['hidden'] %}
+
+{% call form.textarea(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=h.scheming_display_json_value(value, indent=field.get('indent', 2)) if value else None,
+    error=errors[field.field_name],
+    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    classes=visibility,
+    is_required=h.scheming_field_required(field),
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 geojson==2.5.0
-#shapely==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+geojson==2.5.0
+#shapely==1.7.1


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-118

- it requires geojson lib https://pypi.org/project/geojson/,  the PR here https://github.com/salsadigitalauorg/qdes_ckan-29_lagoon/pull/1
- all geojson will be validated either it is valid geojson or not using above lib.

values I used for the test are below:

Lower left  
{ "coordinates": [ 143.360595703125, -23.02918734674458 ], "type": "Point" }

Upper right 
{ "coordinates": [ 144.34936523437497, -22.31958944283391 ], "type": "Point" }

Centroid
{ "coordinates": [ 143.89892578125, -22.735656852206482 ], "type": "Point" }

with geometry since it has no validation I put random geojson.

the points below are the above values.
<img width="366" alt="image" src="https://user-images.githubusercontent.com/1538818/91672147-b2efdb80-eb56-11ea-8543-75107eb4095a.png">

the spatial field is generated based on the points, 
{ "coordinates": [ [ [ 143.360596, -22.319589 ], [ 144.349365, -22.319589 ], [ 144.349365, -23.029187 ], [ 143.360596, -23.029187 ], [ 143.360596, -22.319589 ] ] ], "type": "Polygon" }

**note: the precision is 6 based on the spec on https://tools.ietf.org/html/rfc7946#page-18** however, we can override this, let me know if you want to use precision as per geojson.io

the bounding box, currently only assuming it is rectangel start from upper left -> upper right -> lower right -> lower left -> upper left
![image](https://user-images.githubusercontent.com/1538818/91672199-301b5080-eb57-11ea-91a2-7da841e39d4a.png)

![image](https://user-images.githubusercontent.com/1538818/91672195-27c31580-eb57-11ea-83f4-8a7c5931c17b.png)


