### PR TITLE
[DDCI-119] - added correct date format

### DIFF
--- a/ckanext/qdes_schema/templates/scheming/display_snippets/datetime_tz.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/datetime_tz.html
@@ -1,1 +1,4 @@
-{{ h.render_datetime(data[field.field_name], date_format='%Y-%m-%d %H:%M:%S %Z') }}
+{% if data[field.field_name] %}
+    {% set offset = h.render_datetime(data[field.field_name], date_format='%z') %}
+    {{ h.render_datetime(data[field.field_name], date_format='%Y-%m-%dT%H:%M:%S') }}{{ offset[:3] }}:{{ offset[-2:] }}
+{% endif %}


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-119

python date offset is returning +0700 without `:` so I did something on template level.

![image](https://user-images.githubusercontent.com/1538818/92193909-a1c70780-ee93-11ea-8a72-b431f020e32c.png)
