### PR TITLE
QDCAT Metadata model - Dataset - Contacts and responsibilities

### DIFF
--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -159,6 +159,79 @@
       "sub_heading": "temporal coverage"
     },
     {
+      "field_name": "contact_point",
+      "label": "Point of contact",
+      "display_property": "dcat:contactPoint",
+      "preset": "controlled_vocabulary_single_select",
+      "choices_helper": "scheming_vocabulary_service_choices",
+      "vocabulary_service_name": "contact_point",
+      "display_group": "contacts",
+      "required": true,
+      "form_include_blank_choice": true
+    },
+    {
+      "field_name": "contact_publisher",
+      "label": "Publisher",
+      "display_property": "dcterms:publisher",
+      "preset": "controlled_vocabulary_single_select",
+      "choices_helper": "scheming_vocabulary_service_choices",
+      "vocabulary_service_name": "contact_publisher",
+      "display_group": "contacts",
+      "required": true,
+      "form_include_blank_choice": true
+    },
+    {
+      "field_name": "contact_creator",
+      "label": "Creator",
+      "display_property": "dcterms:creator",
+      "preset": "controlled_vocabulary_multi_select",
+      "vocabulary_service_name": "contact_creator",
+      "display_group": "contacts",
+      "required": false,
+      "form_include_blank_choice": true,
+      "form_attrs": {
+        "class": "form-control"
+      }
+    },
+    {
+      "field_name": "contact_other_party",
+      "label": "Other responsible party",
+      "display_property": "prov:qualifiedAttribution",
+      "preset": "controlled_vocabulary_multi_group_select",
+      "display_group": "contacts",
+      "field_group": [
+        {
+          "field_name": "the-party",
+          "label": "The party",
+          "display_property": "prov:agent",
+          "vocabulary_service_name": "the-party",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        },
+        {
+          "field_name": "nature-of-their-responsibility",
+          "label": "Nature of their responsibility",
+          "display_property": "dcat:hadRole",
+          "vocabulary_service_name": "nature-of-their-responsibility",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        }
+      ]
+    },
+    {
+      "field_name": "acknowledgements",
+      "label": "Acknowledgements",
+      "display_property": "qdcat:acknowledgements",
+      "display_group": "contacts",
+      "form_snippet": "textarea.html"
+    },
+    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "preset": "json_object",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -163,7 +163,6 @@
       "label": "Point of contact",
       "display_property": "dcat:contactPoint",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "contact_point",
       "display_group": "contacts",
       "required": true,
@@ -174,7 +173,6 @@
       "label": "Publisher",
       "display_property": "dcterms:publisher",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "contact_publisher",
       "display_group": "contacts",
       "required": true,
@@ -286,7 +284,6 @@
       "field_name": "spatial_name_code",
       "label": "Name or code",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "spatial_name_code",
       "form_attrs": {
         "data-module": "qdes_autocomplete"
@@ -298,7 +295,6 @@
       "field_name": "spatial_representation",
       "label": "Representation",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "spatial_representation",
       "display_property": "qdcat:hasSpatialRepresentation",
       "display_group": "spatial details"
@@ -307,7 +303,6 @@
       "field_name": "spatial_datum_crs",
       "label": "Datum & CRS",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "spatial_datum_crs",
       "display_property": "qeox:inCRS",
       "display_group": "spatial details"
@@ -316,7 +311,6 @@
       "field_name": "spatial_resolution",
       "label": "Resolution",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "spatial_resolution",
       "display_property": "qdcat:spatialResolution",
       "display_group": "spatial details"
@@ -333,7 +327,6 @@
       "label": "Publication status",
       "display_property": "adms:status",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "publication_status",
       "display_group": "status",
       "required": true
@@ -368,7 +361,6 @@
       "label": "Update schedule",
       "display_property": "dcterms:accrualPeriodicity",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "update_schedule",
       "display_group": "status"
     },
@@ -420,7 +412,6 @@
       "display_property": "dcterms:format",
       "display_snippet": "controlled_vocabulary_single_select.html",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "format",
       "form_attrs": {
         "data-module": "qdes_autocomplete"
@@ -432,7 +423,6 @@
       "label": "Compression",
       "display_property": "dcat:compressFormat",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "compression",
       "form_attrs": {
         "data-module": "qdes_autocomplete"
@@ -443,7 +433,6 @@
       "label": "Packaging",
       "display_property": "dcat:packageFormat",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "packaging",
       "form_attrs": {
         "data-module": "qdes_autocomplete"
@@ -506,7 +495,6 @@
       "label": "License",
       "display_property": "dcterms:license",
       "preset": "controlled_vocabulary_single_select",
-      "choices_helper": "scheming_vocabulary_service_choices",
       "vocabulary_service_name": "license",
       "form_attrs": {
         "data-module": "qdes_autocomplete"

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -16,6 +16,7 @@
       "values": {
         "form_snippet": "select.html",
         "display_snippet": "controlled_vocabulary_single_select.html",
+        "choices_helper": "scheming_vocabulary_service_choices",
         "validators": "scheming_required scheming_choices"
       }
     },


### PR DESCRIPTION
QDCAT Metadata model - Dataset - Contacts and responsibilities
https://it-partners.atlassian.net/browse/DDCI-11

[- Added dataset metadata for contacts and responsibilities](https://github.com/salsa-nathan/ckanext-qdes-schema/commit/8c8de430b6c81db825744b9a8221b86cdafc016c)
[- Added  "choices_helper": "scheming_vocabulary_service_choices" to preset "controlled_vocabulary_single_select"](https://github.com/salsa-nathan/ckanext-qdes-schema/commit/246e530c026b18bf5057bc21b505e2503c0c41ad)

@salsa-nathan Created this branch from `feature/DDCI-117-Description-paramater-pair-fields` to use the multi_group functionality which is still in PR (https://github.com/salsa-nathan/ckanext-qdes-schema/pull/11) and has not been merged into develop. Hence why it's showing a lot more file changes where it should only be 2 files `ckanext/qdes_schema/qdes_ckan_dataset.json`ckanext/qdes_schema/qdes_presets.json`