### PR TITLE
[DDCI-12] - added right and licensing fields

### DIFF
--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -382,7 +382,8 @@
       "label": "Rights statement",
       "form_snippet": "textarea.html",
       "display_property": "dcterms:rights",
-      "display_group": "rights & licensing"
+      "display_group": "rights & licensing",
+      "default_value": "© State of Queensland (Department of Environment and Science) <current_year>"
     },
     {
       "field_name": "license_id",
@@ -397,10 +398,8 @@
       "field_name": "specialized_license",
       "label": "Specialized license",
       "display_property": "odrl:hasPolicy",
-      "display_snippet": "qdes_multi_text.html",
-      "form_snippet": "qdes_multi_text.html",
       "display_group": "rights & licensing",
-      "validators": "qdes_uri_validator"
+      "validators": "url_validator qdes_uri_validator"
     },
     {
       "field_name": "landing_page",
@@ -559,7 +558,7 @@
       "label": "Rights statement",
       "form_snippet": "textarea.html",
       "display_property": "dcterms:rights",
-      "default_value": "© State of Queensland (Department of Environment and Science) 2020"
+      "default_value": "© State of Queensland (Department of Environment and Science) <current_year>"
     },
     {
       "field_name": "license",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -323,13 +323,6 @@
       "display_group": "spatial details"
     },
     {
-      "field_name": "license_id",
-      "label": "License",
-      "form_snippet": "license.html",
-      "help_text": "License definitions and additional information can be found at http://opendefinition.org/",
-      "display_group": "license"
-    },
-    {
       "field_name": "publication_status",
       "label": "Publication status",
       "display_property": "adms:status",
@@ -372,11 +365,42 @@
       "display_group": "status"
     },
     {
+      "field_name": "classification_and_access_restrictions",
+      "label": "Classification and access restrictions",
+      "display_property": "dcterms:accessRights",
+      "display_group": "rights & licensing",
+      "preset": "controlled_vocabulary_multi_select",
+      "vocabulary_service_name": "classification_and_access_restrictions",
+      "form_attrs": {
+        "data-module": "qdes_autocomplete"
+      },
+      "form_include_blank_choice": true,
+      "required": true
+    },
+    {
       "field_name": "rights_statement",
       "label": "Rights statement",
       "form_snippet": "textarea.html",
       "display_property": "dcterms:rights",
       "display_group": "rights & licensing"
+    },
+    {
+      "field_name": "license_id",
+      "label": "License",
+      "display_property": "dcterms:license",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "license_id",
+      "display_group": "rights & licensing",
+      "required": true
+    },
+    {
+      "field_name": "specialized_license",
+      "label": "Specialized license",
+      "display_property": "odrl:hasPolicy",
+      "display_snippet": "qdes_multi_text.html",
+      "form_snippet": "qdes_multi_text.html",
+      "display_group": "rights & licensing",
+      "validators": "qdes_uri_validator"
     },
     {
       "field_name": "landing_page",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -398,6 +398,7 @@
       "field_name": "specialized_license",
       "label": "Specialized license",
       "display_property": "odrl:hasPolicy",
+      "display_snippet": "qdes_text_url.html",
       "display_group": "rights & licensing",
       "validators": "url_validator qdes_uri_validator"
     },
@@ -443,7 +444,7 @@
     {
       "field_name": "lineage_inputs",
       "label": "Inputs",
-      "display_snippet": "qdes_multi_text.html",
+      "display_snippet": "qdes_multi_text_url.html",
       "form_snippet": "qdes_multi_text.html",
       "validators": "qdes_uri_validator",
       "display_group": "related and lineage",
@@ -472,7 +473,7 @@
       "field_name": "schema_standards",
       "label": "Schema, standard(s)",
       "display_property": "dcterms:conformsTo",
-      "display_snippet": "qdes_multi_text.html",
+      "display_snippet": "qdes_multi_text_url.html",
       "form_snippet": "qdes_multi_text.html",
       "validators": "qdes_uri_validator"
     },
@@ -521,6 +522,7 @@
       "field_name": "url",
       "label": "Download address",
       "display_property": "dcat:downloadURL",
+      "display_snippet": "qdes_text_url.html",
       "validators": "url_validator qdes_uri_validator",
       "recommended": true
     },
@@ -528,7 +530,7 @@
       "field_name": "service_api_endpoint",
       "label": "Service API end-point",
       "display_property": "dcterms:conformsTo",
-      "display_snippet": "qdes_multi_text.html",
+      "display_snippet": "qdes_multi_text_url.html",
       "form_snippet": "qdes_multi_text.html"
     },
     {

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/controlled_vocabulary_single_select.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/controlled_vocabulary_single_select.html
@@ -1,6 +1,6 @@
 {% if data[field.field_name]|length > 0 %}
-{# temporary generation of labels from URI or from a lookup list if the URIs are from BFO #}
-{% set label = data[field.field_name].split('/')[-1] %}
+    {# temporary generation of labels from URI or from a lookup list if the URIs are from BFO #}
+    {% set label = data[field.field_name].split('/')[-1] %}
     {% if label is not none %}
       {# <a href="{{ data[field.field_name] }}">{{ label }}</a> #}
         <a href="{{ data[field.field_name] }}">{{ h.scheming_choices_label(

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_text_url.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_text_url.html
@@ -1,6 +1,6 @@
 {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 {% for value in values %}
-    <div>{{ value }}</div>
+    <div><a href="{{ value }}">{{ value }}</a></div>
     {% if not loop.last %}
         <hr>
     {% endif %} 

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_text_url.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_text_url.html
@@ -1,0 +1,1 @@
+<a href="{{ data[field.field_name] }}">{{ data[field.field_name] }}</a>

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/text.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/text.html
@@ -1,4 +1,9 @@
-{%- set display_as_link = ['url'] -%}
+{%
+set display_as_link = [
+    'url',
+    'specialized_license'
+]
+%}
 
 {% if field.field_name in display_as_link %}
     <a href="{{ data[field.field_name] }}">{{ data[field.field_name] }}</a>

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/textarea.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/textarea.html
@@ -3,7 +3,7 @@
 {% if data['id']|length > 0 %}
     {% set default_value = data[field.field_name] %}
 {% else %}
-    {% set default_value = data[field.field_name] if data[field.field_name]|length > 0 else field.default_value %}
+    {% set default_value = data[field.field_name] if data[field.field_name]|length > 0 else field.default_value|replace('<current_year>', h.render_datetime(h.get_current_datetime(), '%Y')) %}
 {% endif %}
 
 {% call form.textarea(

--- a/ckanext/qdes_schema/templates/snippets/license.html
+++ b/ckanext/qdes_schema/templates/snippets/license.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block license_content_inner %}
+    {% set data = pkg_dict %}
+    {% set schema = h.scheming_get_schema('dataset', 'dataset') %}
+    {% set field = h.scheming_field_by_name(schema.dataset_fields, 'license_id') %}
+
+    {% include '/scheming/display_snippets/controlled_vocabulary_single_select.html' %}
+{% endblock %}


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-12
https://it-partners.atlassian.net/browse/DDCI-10

- with license_id, it seems the default template render it on left hand side, so I just update to print the label as link.

![image](https://user-images.githubusercontent.com/1538818/92461470-86416100-f1f3-11ea-9bc6-99021a7457be.png)

![screencapture-qdes-ckan-29-docker-amazee-io-dataset-test-2020-09-08-16_50_01](https://user-images.githubusercontent.com/1538818/92461388-7033a080-f1f3-11ea-8b15-22e5753359e4.png)
