### PR TITLE
[DDCI-9] QDCAT Metadata model - Dataset - Related and lineage

### DIFF
--- a/ckanext/qdes_schema/fanstatic/repeating-fields.js
+++ b/ckanext/qdes_schema/fanstatic/repeating-fields.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function () {
 
         show: function () {
             // Check to see if there is any select elements with an autocomplete data module
-            jQuery(this).find('select[data-module="qdes_autocomplete"]').map(function (index, select) {
+            jQuery(this).find('[data-module="qdes_autocomplete"]').map(function (index, select) {
                 // Initialize autocomplete data for select element
                 ckan.module.initializeElement(select);
             });
@@ -15,7 +15,7 @@ jQuery(document).ready(function () {
             if (confirm('Are you sure you want to remove this item?')) {
                 // Remove value and trigger events
                 jQuery(this).hide();
-                jQuery(this).find('.form-control, select[data-module="qdes_autocomplete"]').val('').blur().change();
+                jQuery(this).find('.form-control, [data-module="qdes_autocomplete"]').val('').blur().change();
             }
         },
         ready: function (setIndexes) {
@@ -25,7 +25,7 @@ jQuery(document).ready(function () {
     });
 
     function collate_inputs(repeater_id, target_field_id, field_type) {
-        var multi_groups = jQuery('#' + repeater_id + ' [data-repeater-item]:visible' + ' ' + field_type + '[data-group="True"]')
+        var multi_groups = jQuery('#' + repeater_id + ' [data-repeater-item]:visible' + ' [data-group="True"]')
         var collated_values = multi_groups.length > 0 ? {} : [];
 
         if (multi_groups.length > 0) {
@@ -79,12 +79,12 @@ jQuery(document).ready(function () {
         update_repeater_fields(this);
     });
 
-    jQuery(document).on('change', ".repeating-field select[data-module='qdes_autocomplete']", function () {
+    jQuery(document).on('change', ".repeating-field [data-module='qdes_autocomplete']", function () {
         update_repeater_fields(this);
     });
 
     // On load trigger the on change/blur for repeatable fields,
     // otherwise required fields won't have value by default.
     jQuery(".repeating-field .form-control").blur();
-    jQuery(".repeating-field select[data-module='qdes_autocomplete']").change();
+    jQuery(".repeating-field [data-module='qdes_autocomplete']").change();
 });

--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -1,11 +1,11 @@
 import datetime
 import logging
 
-from ckan.common import config
-from ckan.plugins.toolkit import h
-from ckan.plugins.toolkit import get_action
+from ckan.plugins.toolkit import config, h, get_action
+
 
 log = logging.getLogger(__name__)
+
 
 def is_legacy_ckan():
     return False if h.ckan_version() > '2.9' else True
@@ -38,6 +38,25 @@ def qdes_dataservice_choices(field):
             choices.append({
                 'value': config.get('ckan.site_url', None) + '/dataservice/' + data.name,
                 'label': data.title
+            })
+    except Exception as e:
+        log.error(str(e))
+
+    return choices
+
+
+def qdes_relationship_types_choices(field):
+    """
+    Return choices for dataset relationship types.
+    """
+    choices = []
+
+    try:
+        for data in h.get_relationship_types():
+            log.debug('qdes_relationship_types_choices: {0}'.format(data))
+            choices.append({
+                'value': data[0],
+                'label': data[0]
             })
     except Exception as e:
         log.error(str(e))

--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -53,7 +53,7 @@ def qdes_relationship_types_choices(field):
 
     try:
         for data in h.get_relationship_types():
-            log.debug('qdes_relationship_types_choices: {0}'.format(data))
+            #log.debug('qdes_relationship_types_choices: {0}'.format(data))
             choices.append({
                 'value': data[0],
                 'label': data[0]

--- a/ckanext/qdes_schema/logic/action/get.py
+++ b/ckanext/qdes_schema/logic/action/get.py
@@ -1,18 +1,20 @@
 import logging
-import requests
-
-from ckan.plugins.toolkit import get_action
-from ckan import model
-from ckan.model import meta
+import ckan.plugins.toolkit as toolkit
+import ckan.logic as logic
+import ckan.authz as authz
+import ckan.lib.plugins as lib_plugins
+import ckan.lib.search as search
 
 log = logging.getLogger(__name__)
+_check_access = toolkit.check_access
+
 
 def dataservice(context, name):
     """
     Returns all dataservice where private is false.
     """
     data = []
-
+    model = context['model']
     try:
         cls = model.Package
         data = model.Package().Session.query(cls).filter(cls.type == 'dataservice').filter(cls.private == 'f').all()
@@ -20,3 +22,63 @@ def dataservice(context, name):
         log.error(str(e))
 
     return data
+
+
+@toolkit.chained_action
+def package_autocomplete(original_action, context, data_dict):
+    '''Return a list of datasets (packages) that match a string.
+
+    Datasets with names or titles that contain the query string will be
+    returned.
+
+    :param q: the string to search for
+    :type q: string
+    :param limit: the maximum number of resource formats to return (optional,
+        default: ``10``)
+    :type limit: int
+
+    :rtype: list of dictionaries
+
+    '''
+    # Override of package_autocomplete
+    # The only change is to only search on public datasets and ignore private datasets
+    model = context.get('model')
+
+    _check_access('package_autocomplete', context, data_dict)
+    user = context.get('user')
+
+    limit = data_dict.get('limit', 10)
+    q = data_dict['q']
+
+    data_dict = {
+        'q': ' OR '.join([
+            'name_ngram:{0}',
+            'title_ngram:{0}',
+            'name:{0}',
+            'title:{0}',
+        ]).format(search.query.solr_literal(q)),
+        'fl': 'name,title',
+        'fq': 'capacity:public',  # QDes Override: Only search on public datasets
+        'rows': limit
+    }
+    query = search.query_for(model.Package)
+
+    results = query.run(data_dict)['results']
+
+    q_lower = q.lower()
+    pkg_list = []
+    for package in results:
+        if q_lower in package['name']:
+            match_field = 'name'
+            match_displayed = package['name']
+        else:
+            match_field = 'title'
+            match_displayed = '%s (%s)' % (package['title'], package['name'])
+        result_dict = {
+            'name': package['name'],
+            'title': package['title'],
+            'match_field': match_field,
+            'match_displayed': match_displayed}
+        pkg_list.append(result_dict)
+
+    return pkg_list

--- a/ckanext/qdes_schema/logic/helpers/relationship_helpers.py
+++ b/ckanext/qdes_schema/logic/helpers/relationship_helpers.py
@@ -1,0 +1,44 @@
+import ckan.plugins.toolkit as toolkit
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def convert_related_resources_to_dict_list(related_resources):
+    """
+    The package.related_resources field is stored as a JSON string
+    and currently stores related resources in the form:
+
+        {"resources":["http://www.google.com","dataset-a","first-dataset"],"relationships":["isPartOf","unspecified relationship","unspecified relationship"],"count":3}
+
+    to make it easier to process related resources when processing relationships
+    we convert it to a list of dict objects, where each dict contains 1 relationship, e.g.
+
+        [
+            {'resource': 'http://www.google.com', 'relationship': 'isPartOf', 'source': 'external'},
+            {'resource': 'dataset-a', 'relationship': 'unspecified relationship', 'source': 'ckan'},
+            ...
+        ]
+
+    :param related_resources:
+    :return:
+    """
+    dict_list = []
+
+    related_resources = toolkit.get_converter('json_or_string')(related_resources)
+
+    if isinstance(related_resources, dict):
+
+        for i in range(0, related_resources.get('count', 0)):
+            data_dict = {
+                'resource': related_resources['resources'][i],
+                'relationship': related_resources['relationships'][i],
+                'source': 'ckan'
+            }
+
+            if data_dict['resource'].startswith('http'):
+                data_dict['source'] = 'external'
+
+            dict_list.append(data_dict)
+
+    return dict_list

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -79,6 +79,6 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     def get_actions(self):
         return {
             'get_dataservice': get.dataservice,
-            'package_autocomplete': get.package_autocomplete
+            'package_autocomplete': get.package_autocomplete,
             'update_dataservice_datasets_available': update.dataservice_datasets_available
         }

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -4,7 +4,7 @@ import json
 
 from ckanext.qdes_schema import helpers, validators
 from ckanext.qdes_schema.logic.action import get, update
-
+from ckanext.relationships import helpers as ckanext_relationships_helpers
 
 
 class QDESSchemaPlugin(plugins.SingletonPlugin):
@@ -20,6 +20,17 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
 
     def after_create(self, context, pkg_dict):
         pass
+
+    def before_index(self, pkg_dict):
+        # Remove the relationship type fields from the pkg_dict to prevent indexing from breaking
+        # because we removed the relationship type fields from solr schema.xml
+        relationship_types = ckanext_relationships_helpers.get_relationship_types_as_flat_list()
+
+        for relationship_type in relationship_types:
+            if pkg_dict.get(relationship_type, None):
+                pkg_dict.pop(relationship_type)
+
+        return pkg_dict
 
     # IValidators
     def get_validators(self):

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -5,6 +5,7 @@ import json
 from ckanext.qdes_schema import helpers, validators
 from ckanext.qdes_schema.logic.action import get
 
+
 class QDESSchemaPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
@@ -25,7 +26,9 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'qdes_validate_geojson_spatial': validators.qdes_validate_geojson_spatial,
             'qdes_spatial_points_pair': validators.qdes_spatial_points_pair,
             'qdes_iso_8601_durations': validators.qdes_iso_8601_durations,
-            'qdes_validate_multi_groups': validators.qdes_validate_multi_groups
+            'qdes_validate_multi_groups': validators.qdes_validate_multi_groups,
+            'qdes_validate_related_dataset': validators.qdes_validate_related_dataset,
+            'qdes_validate_related_resources': validators.qdes_validate_related_resources
         }
 
     # IConfigurer
@@ -51,6 +54,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'set_first_option': helpers.set_first_option,
             'get_current_datetime': helpers.get_current_datetime,
             'qdes_dataservice_choices': helpers.qdes_dataservice_choices,
+            'qdes_relationship_types_choices': helpers.qdes_relationship_types_choices
         }
 
     def get_multi_textarea_values(self, value):
@@ -65,5 +69,6 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     # IActions
     def get_actions(self):
         return {
-            'get_dataservice': get.dataservice
+            'get_dataservice': get.dataservice,
+            'package_autocomplete': get.package_autocomplete
         }

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -428,6 +428,48 @@
       "form_placeholder": "1.0"
     },
     {
+      "field_name": "series_or_collection",
+      "label": "Series or collection",
+      "preset": "dataset_related_multi_text"
+    },
+    {
+      "field_name": "related_datasets",
+      "label": "Related dataset",
+      "preset": "dataset_related_multi_text"
+    },
+    {
+      "field_name": "related_resources",
+      "label": "Related resource",
+      "display_group": "related and lineage",
+      "sub_heading": "related",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_related_resources",
+      "field_group": [
+        {
+          "field_name": "resources",
+          "label": "Resource",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "data-module": "qdes_autocomplete",
+            "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
+            "data-module-create-search-choice": true,
+            "class": "form-control"
+          }
+        },
+        {
+          "field_name": "relationships",
+          "label": "Relationship",
+          "form_snippet": "select.html",
+          "choices_helper": "qdes_relationship_types_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        }
+      ]
+    },
+    {
       "field_name": "lineage_description",
       "label": "Description",
       "form_snippet": "markdown.html",
@@ -465,6 +507,15 @@
       "label": "Responsible party",
       "preset": "controlled_vocabulary_single_select",
       "vocabulary_service_name": "creator",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "cited_in",
+      "label": "Cited in",
+      "display_snippet": "qdes_multi_text_url.html",
+      "form_snippet": "qdes_multi_text.html",
+      "validators": "qdes_uri_validator",
       "display_group": "related and lineage",
       "sub_heading": "lineage"
     }

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -166,77 +166,6 @@
       "display_group": "temporal content"
     },
     {
-      "field_name": "contact_point",
-      "label": "Point of contact",
-      "display_property": "dcat:contactPoint",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_point",
-      "display_group": "contacts",
-      "required": true,
-      "form_include_blank_choice": true
-    },
-    {
-      "field_name": "contact_publisher",
-      "label": "Publisher",
-      "display_property": "dcterms:publisher",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_publisher",
-      "display_group": "contacts",
-      "required": true,
-      "form_include_blank_choice": true
-    },
-    {
-      "field_name": "contact_creator",
-      "label": "Creator",
-      "display_property": "dcterms:creator",
-      "preset": "controlled_vocabulary_multi_select",
-      "vocabulary_service_name": "contact_creator",
-      "display_group": "contacts",
-      "required": false,
-      "form_include_blank_choice": true,
-      "form_attrs": {
-        "class": "form-control"
-      }
-    },
-    {
-      "field_name": "contact_other_party",
-      "label": "Other responsible party",
-      "display_property": "prov:qualifiedAttribution",
-      "preset": "controlled_vocabulary_multi_group_select",
-      "display_group": "contacts",
-      "field_group": [
-        {
-          "field_name": "the-party",
-          "label": "The party",
-          "display_property": "prov:agent",
-          "vocabulary_service_name": "the-party",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
-        },
-        {
-          "field_name": "nature-of-their-responsibility",
-          "label": "Nature of their responsibility",
-          "display_property": "dcat:hadRole",
-          "vocabulary_service_name": "nature-of-their-responsibility",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
-        }
-      ]
-    },
-    {
-      "field_name": "acknowledgements",
-      "label": "Acknowledgements",
-      "display_property": "qdcat:acknowledgements",
-      "display_group": "contacts",
-      "form_snippet": "textarea.html"
-    },
-    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "form_snippet": "textarea.html",
@@ -321,6 +250,169 @@
       "vocabulary_service_name": "spatial_resolution",
       "display_property": "qdcat:spatialResolution",
       "display_group": "spatial details"
+    },
+    {
+      "field_name": "series_or_collection",
+      "label": "Series or collection",
+      "preset": "dataset_related_multi_text"
+    },
+    {
+      "field_name": "related_datasets",
+      "label": "Related dataset",
+      "preset": "dataset_related_multi_text"
+    },
+    {
+      "field_name": "related_resources",
+      "label": "Related resource",
+      "display_group": "related and lineage",
+      "sub_heading": "related",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_related_resources",
+      "field_group": [
+        {
+          "field_name": "resources",
+          "label": "Resource",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "data-module": "qdes_autocomplete",
+            "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
+            "data-module-create-search-choice": true,
+            "class": "form-control"
+          }
+        },
+        {
+          "field_name": "relationships",
+          "label": "Relationship",
+          "form_snippet": "select.html",
+          "choices_helper": "qdes_relationship_types_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        }
+      ]
+    },
+    {
+      "field_name": "lineage_description",
+      "label": "Description",
+      "form_snippet": "markdown.html",
+      "display_snippet": "markdown.html",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "lineage_plan",
+      "label": "Plan",
+      "display_snippet": "qdes_text_url.html",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "lineage_inputs",
+      "label": "Inputs",
+      "display_snippet": "qdes_multi_text_url.html",
+      "form_snippet": "qdes_multi_text.html",
+      "validators": "qdes_uri_validator",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "lineage_sensor",
+      "label": "Sensor",
+      "display_snippet": "qdes_multi_text_url.html",
+      "form_snippet": "qdes_multi_text.html",
+      "validators": "qdes_uri_validator",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "lineage_responsible_party",
+      "label": "Responsible party",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "creator",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "cited_in",
+      "label": "Cited in",
+      "display_snippet": "qdes_multi_text_url.html",
+      "form_snippet": "qdes_multi_text.html",
+      "validators": "qdes_uri_validator",
+      "display_group": "related and lineage",
+      "sub_heading": "lineage"
+    },
+    {
+      "field_name": "contact_point",
+      "label": "Point of contact",
+      "display_property": "dcat:contactPoint",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "contact_point",
+      "display_group": "contacts",
+      "required": true,
+      "form_include_blank_choice": true
+    },
+    {
+      "field_name": "contact_publisher",
+      "label": "Publisher",
+      "display_property": "dcterms:publisher",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "contact_publisher",
+      "display_group": "contacts",
+      "required": true,
+      "form_include_blank_choice": true
+    },
+    {
+      "field_name": "contact_creator",
+      "label": "Creator",
+      "display_property": "dcterms:creator",
+      "preset": "controlled_vocabulary_multi_select",
+      "vocabulary_service_name": "contact_creator",
+      "display_group": "contacts",
+      "required": false,
+      "form_include_blank_choice": true,
+      "form_attrs": {
+        "class": "form-control"
+      }
+    },
+    {
+      "field_name": "contact_other_party",
+      "label": "Other responsible party",
+      "display_property": "prov:qualifiedAttribution",
+      "preset": "controlled_vocabulary_multi_group_select",
+      "display_group": "contacts",
+      "field_group": [
+        {
+          "field_name": "the-party",
+          "label": "The party",
+          "display_property": "prov:agent",
+          "vocabulary_service_name": "the-party",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        },
+        {
+          "field_name": "nature-of-their-responsibility",
+          "label": "Nature of their responsibility",
+          "display_property": "dcat:hadRole",
+          "vocabulary_service_name": "nature-of-their-responsibility",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "form_attrs": {
+            "class": "form-control"
+          },
+          "form_include_blank_choice": true
+        }
+      ]
+    },
+    {
+      "field_name": "acknowledgements",
+      "label": "Acknowledgements",
+      "display_property": "qdcat:acknowledgements",
+      "display_group": "contacts",
+      "form_snippet": "textarea.html"
     },
     {
       "field_name": "publication_status",
@@ -426,98 +518,6 @@
       "label": "Version",
       "validators": "ignore_missing unicode package_version_validator",
       "form_placeholder": "1.0"
-    },
-    {
-      "field_name": "series_or_collection",
-      "label": "Series or collection",
-      "preset": "dataset_related_multi_text"
-    },
-    {
-      "field_name": "related_datasets",
-      "label": "Related dataset",
-      "preset": "dataset_related_multi_text"
-    },
-    {
-      "field_name": "related_resources",
-      "label": "Related resource",
-      "display_group": "related and lineage",
-      "sub_heading": "related",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "ignore_empty qdes_validate_related_resources",
-      "field_group": [
-        {
-          "field_name": "resources",
-          "label": "Resource",
-          "form_snippet": "text.html",
-          "form_attrs": {
-            "data-module": "qdes_autocomplete",
-            "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
-            "data-module-create-search-choice": true,
-            "class": "form-control"
-          }
-        },
-        {
-          "field_name": "relationships",
-          "label": "Relationship",
-          "form_snippet": "select.html",
-          "choices_helper": "qdes_relationship_types_choices",
-          "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
-        }
-      ]
-    },
-    {
-      "field_name": "lineage_description",
-      "label": "Description",
-      "form_snippet": "markdown.html",
-      "display_snippet": "markdown.html",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
-    },
-    {
-      "field_name": "lineage_plan",
-      "label": "Plan",
-      "display_snippet": "qdes_text_url.html",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
-    },
-    {
-      "field_name": "lineage_inputs",
-      "label": "Inputs",
-      "display_snippet": "qdes_multi_text_url.html",
-      "form_snippet": "qdes_multi_text.html",
-      "validators": "qdes_uri_validator",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
-    },
-    {
-      "field_name": "lineage_sensor",
-      "label": "Sensor",
-      "display_snippet": "qdes_multi_text_url.html",
-      "form_snippet": "qdes_multi_text.html",
-      "validators": "qdes_uri_validator",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
-    },
-    {
-      "field_name": "lineage_responsible_party",
-      "label": "Responsible party",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "creator",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
-    },
-    {
-      "field_name": "cited_in",
-      "label": "Cited in",
-      "display_snippet": "qdes_multi_text_url.html",
-      "form_snippet": "qdes_multi_text.html",
-      "validators": "qdes_uri_validator",
-      "display_group": "related and lineage",
-      "sub_heading": "lineage"
     }
   ],
   "resource_fields": [

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -52,6 +52,21 @@
         "display_snippet": "qdes_duration.html",
         "validators": "qdes_iso_8601_durations"
       }
+    },
+    {
+      "preset_name": "dataset_related_multi_text",
+      "values": {
+        "display_group": "related and lineage",
+        "sub_heading": "related",
+        "display_snippet": "qdes_multi_text.html",
+        "form_snippet": "qdes_multi_text.html",
+        "validators": "ignore_empty qdes_validate_related_dataset",
+        "form_attrs": {
+          "data-module": "qdes_autocomplete",
+          "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
+          "data-module-create-search-choice": true
+        }
+      }
     }
   ]
 }

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
@@ -1,0 +1,16 @@
+{% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
+
+{% for row in range(values['count']|int)  %}             
+    <div>
+        {% for field_group in field.get('field_group') or [] %}      
+            {% set value = values[field_group.field_name][row]|string %}
+            <span>{{ value }}</span>
+            {% if not loop.last %}
+                <span> - </span>            
+            {% endif %}
+        {% endfor %}
+    <div>
+    {% if not loop.last %}
+        <hr>           
+    {% endif %}
+{% endfor %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/select.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/select.html
@@ -1,0 +1,39 @@
+{% import 'macros/form.html' as form %}
+
+{%- set options=[] -%}
+{%- set form_restrict_choices_to=field_group.get('form_restrict_choices_to') -%}
+{%- if not h.scheming_field_required(field_group) or
+  field_group.get('form_include_blank_choice', false) -%}
+  {%- do options.append({'value': '', 'text': ''}) -%}
+{%- endif -%}
+{%- for c in h.scheming_field_choices(field_group) -%}
+  {%- if not form_restrict_choices_to or c.value in form_restrict_choices_to -%}
+    {%- do options.append({
+      'value': c.value|string,
+      'text': h.scheming_language_text(c.label) }) -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if field_group.get('sorted_choices') -%}
+  {%- set options = options|sort(case_sensitive=false, attribute='text') -%}
+{%- endif -%}
+{%- if field_group.get('first_choice') -%}
+  {%- set options = h.set_first_option(options, field_group.get('first_choice')) -%}
+{%- endif -%}
+{%- if values[field_group.field_name] -%}
+  {%- set option_selected = values[field_group.field_name][row]|string -%}
+{%- else -%}
+  {%- set option_selected = None -%}
+{%- endif -%}
+
+{% call form.select(
+    label=h.scheming_language_text(field_group.label),
+    options=options,
+    selected=option_selected,
+    error=errors[field_group.field_name],
+    classes=['control-medium'],
+    attrs=dict({"data-group": true, "data-field-name": field_group.field_name, "data-parent-field-name": field.field_name, "data-placeholder":"Select a {0}".format(field_group.label)}, **(field_group.get('form_attrs', {}))),
+    is_required=h.scheming_field_required(field_group)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field_group -%}
+{% endcall %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
@@ -1,0 +1,27 @@
+{% import 'macros/form.html' as form %}
+
+{%- if values[field_group.field_name] -%}
+    {%- set value = values[field_group.field_name][row]|string -%}
+{%- else -%}
+    {%- set value = None -%}
+{%- endif -%}
+
+{%
+    call form.input(
+        label=h.scheming_language_text(field_group.label),
+        placeholder=h.scheming_language_text(field_group.form_placeholder),
+        attrs=dict(
+            {
+            "data-group": true, 
+            "data-field-name": field_group.field_name, 
+            "data-parent-field-name": field.field_name, 
+            "data-placeholder":"Select a {0}".format(field_group.label),
+            "data-module-id": data.get('id', '')
+            }, 
+            **(field_group.get('form_attrs', {}))),
+        is_required=h.scheming_field_required(field_group),
+        value=value,
+        error=errors[field_group.field_name]
+    )
+%}
+{% endcall %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
@@ -1,0 +1,48 @@
+{% import 'macros/form.html' as form %}
+
+<div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="select">
+    <label class="control-label" for="field-{{ field.field_name }}">{{ field.label }}</label>
+    {% if errors[field.field_name] and errors[field.field_name] is iterable %}<span class="error-block">{{ errors[field.field_name]|join(', ') }}</span>{% endif %}
+    <div data-repeater-list="{{ field.field_name }}">
+
+        {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
+        {% set count = values['count']|int if values['count']|int > 0 else 1 %}
+        {% for row in range(count)  %}   
+
+          <div data-repeater-item class="row vertical-align">
+            {% for field_group in field.get('field_group') or [] %}          
+
+              <div class="col-lg-{{ 12 // field.get('field_group')|length }}">              
+                {% if field_group.form_snippet %}
+                  {%- snippet 'scheming/form_snippets/field_groups/{0}'.format(field_group.form_snippet), field=field, field_group=field_group, values=values, row=row, errors=errors, data=data or {} -%}
+                {% endif %}
+              </div>
+            {% endfor %}            
+            <div class="col-lg-1">
+                  <input data-repeater-delete type="button" class="btn btn-sm btn-danger" value="-" title="Remove item" />
+            </div>
+          </div>
+        {% endfor %}
+
+    </div>
+    <div class="row" align="center">
+        <input data-repeater-create type="button" class="btn" value="+" />
+    </div>
+</div>
+
+{% set visibility = [] if g.debug else ['hidden'] %}
+{% set default_classes = field.classes if 'classes' in field else [] %}
+{% set ns = namespace(field_classes=default_classes + visibility) %}
+
+{# BEGIN: The actual form field the multiple values will be captured & submitted in #}
+{% call form.textarea(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    value=data[field.field_name],
+    classes=ns.field_classes,
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}
+{# END: The actual form field the multiple values will be captured & submitted in #}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
@@ -13,7 +13,7 @@
                         call form.input(
                             label=h.scheming_language_text(field.label),
                             placeholder=h.scheming_language_text(field.form_placeholder),
-                            attrs=dict({"class": "form-control", "data-field-name": field.field_name}, **(field.get('form_attrs', {}))),
+                            attrs=dict({"class": "form-control", "data-field-name": field.field_name, "data-placeholder":"Select a {0}".format(field.label)}, **(field.get('form_attrs', {}))),
                             is_required=h.scheming_field_required(field),
                             value=value,
                             error=errors[field.field_name]
@@ -44,9 +44,7 @@
         label=h.scheming_language_text(field.label),
         placeholder=h.scheming_language_text(field.form_placeholder),
         value=data[field.field_name],
-        error=errors[field.field_name],
         classes=default_classes + visibility,
-        attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
         is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_select.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_select.html
@@ -1,0 +1,15 @@
+{% import 'macros/form.html' as form %}
+
+
+{% call form.select(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    error=errors[field.field_name],
+    classes=['control-medium'],
+    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    is_required=h.scheming_field_required(field)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -32,6 +32,7 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
             elif key == ('temporal_end',):
                 raise toolkit.Invalid('Must be later than start date.')
 
+
 def qdes_dataset_current_date_later_than_creation(key, flattened_data, errors, context):
     """
     Validate current date field against dataset_creation_date field.
@@ -243,3 +244,55 @@ def qdes_validate_multi_groups(field, schema):
                     errors[key].append(toolkit._('{0} field should not be empty'.format(field_group.get('label'))))
 
     return validator
+
+
+@scheming_validator
+def qdes_validate_related_resources(field, schema):
+    """
+    Validates each multi group for related_resources
+    Must not have empty values in group
+    Must be either a valid CKAN dataset name or valid URL to external dataset
+    """
+
+    def validator(key, data, errors, context):
+        key_data = data.get(key)
+        field_groups = field.get('field_group')
+        if key_data and field_groups:
+            values = toolkit.h.get_multi_textarea_values(key_data)
+            for field_group in field_groups:
+                group_values = values.get(field_group.get('field_name', ''), [])
+                # Check if there are any missing empty values in the group
+                if any(values for value in group_values if value == None or value.strip() == ''):
+                    errors[key].append(toolkit._('{0} field should not be empty'.format(field_group.get('label'))))
+                elif field_group.get('field_name') == 'resources':
+                    # Check if dataset name exists or is a valid URL
+                    try:
+                        qdes_validate_related_dataset(group_values, context)
+                    except toolkit.Invalid as e:
+                        errors[key].append(toolkit._('{0} - {1}'.format(field_group.get('label'), e.error)))
+
+    return validator
+
+
+def qdes_validate_related_dataset(value, context):
+    """
+    Validates each dataset name exists in CKAN or is a valid URL to external dataset
+    """
+    log.debug('qdes_dataset_related - {0}'.format(value))
+    datasets = related_resources = toolkit.get_converter('json_or_string')(value)
+    if datasets and isinstance(datasets, list):
+        for dataset in datasets:
+            try:
+                toolkit.get_validator('package_name_exists')(dataset, context)
+            except toolkit.Invalid:
+                # Package does not exists so lets check to see if there is a valid URI entereds
+                data = {'url': dataset}
+                errors = {'url': []}
+                toolkit.get_validator('url_validator')('url', data, errors, context)
+                if(len(errors['url']) > 0):
+                    raise toolkit.Invalid(errors['url'][0])
+
+                if not toolkit.get_validator('qdes_uri_validator')(dataset):
+                    raise toolkit.Invalid('Unsuccessful connecting to URI "{}'.format(dataset))
+
+    return value


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-9
- Added new metadata fields: series_or_collection, related_datasets, related_resources, cited_in
- Added new validators for related_datasets and related_resources
- Added new helper 'qdes_relationship_types_choices'
- Added action override for 'package_autocomplete' to return only public datasets
- Added 'createSearchChoice' option for autocomplete to allow or disallow user to entering new choice options. Similar to creating tags
- Added new 'qdes_multi_group.html' template to group metadata elements together
- Added new snippets for multi group elements