### PR TITLE
[DDCI-121] QDCAT Metadata model - Data Service - Related and lineage

### DIFF
--- a/ckanext/qdes_schema/fanstatic/autocomplete.js
+++ b/ckanext/qdes_schema/fanstatic/autocomplete.js
@@ -33,7 +33,8 @@ jQuery(document).ready(function () {
         containerClass: '',
         allowClear: true,
         createSearchChoice: false,
-        id: ''
+        id: '',
+        type: ''
       },
 
       /* Sets up the module, binding methods, creating elements etc. Called
@@ -138,6 +139,12 @@ jQuery(document).ready(function () {
         var parts = this.options.source.split('?');
         var end = parts.pop();
         var source = parts.join('?') + encodeURIComponent(string) + end;
+        if (this.options.id) {
+          source += "&dataset_id=" + this.options.id;
+        }
+        if (this.options.type) {
+          source += "&dataset_type=" + this.options.type;
+        }
         var client = this.sandbox.client;
         var options = {
           format: function (data) {

--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -82,22 +82,19 @@ def update_related_resources(context, pkg_dict, reconcile_relationships=False):
         remove_duplicate_related_resources(pkg_dict)
         reconcile_package_relationships(context, pkg_dict['id'], pkg_dict.get('related_resources', None))
 
-    create_series_or_collection_relationships(context, pkg_dict)
-    create_related_datasets_relationships(context, pkg_dict)
+    if pkg_dict.get('type') == 'dataset':
+        create_related_relationships(context, pkg_dict, 'series_or_collection', 'isPartOf')
+        create_related_relationships(context, pkg_dict, 'related_datasets', 'unspecified relationship')
+    elif pkg_dict.get('type') == 'dataservice':
+        create_related_relationships(context, pkg_dict, 'related_services', 'unspecified relationship')
+
     create_related_resource_relationships(context, pkg_dict)
-    data_dict = {"id": pkg_dict.get('id'), "related_resources": pkg_dict.get('related_resources')}
+    data_dict = {"id": pkg_dict.get('id')}
     get_action('update_related_resources')(context, data_dict)
 
 
-def create_series_or_collection_relationships(context, pkg_dict):
-    datasets = get_converter('json_or_string')(pkg_dict.get('series_or_collection', []))
-    relationship_type = 'isPartOf'
-    add_related_resources(pkg_dict, datasets, relationship_type)
-
-
-def create_related_datasets_relationships(context, pkg_dict):
-    datasets = get_converter('json_or_string')(pkg_dict.get('related_datasets', []))
-    relationship_type = 'unspecified relationship'
+def create_related_relationships(context, pkg_dict, metadata_field, relationship_type):
+    datasets = get_converter('json_or_string')(pkg_dict.get(metadata_field, []))
     add_related_resources(pkg_dict, datasets, relationship_type)
 
 

--- a/ckanext/qdes_schema/logic/action/update.py
+++ b/ckanext/qdes_schema/logic/action/update.py
@@ -86,6 +86,9 @@ def update_related_resources(context, data_dict):
                 related_datasets = dataset._extras.get('related_datasets', None)
                 if related_datasets:
                     related_datasets.value = None
+                related_services = dataset._extras.get('related_services', None)
+                if related_services:
+                    related_services.value = None
 
                 dataset.commit()
 

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -36,8 +36,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
         domain object, which may not include all fields). Also the newly
         created dataset id will be added to the dict.
         '''
-        if pkg_dict['type'] == 'dataset':
-            helpers.update_related_resources(context, pkg_dict, False)
+        helpers.update_related_resources(context, pkg_dict, False)
 
         return pkg_dict
 
@@ -46,8 +45,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
         Extensions will receive the validated data dict after the dataset
         has been updated.
         '''
-        if pkg_dict['type'] == 'dataset':
-            helpers.update_related_resources(context, pkg_dict, True)
+        helpers.update_related_resources(context, pkg_dict, True)
 
         return pkg_dict
 

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -331,38 +331,7 @@
       "preset": "dataset_related_multi_text"
     },
     {
-      "field_name": "related_resources",
-      "label": "Related resource",
-      "display_group": "related and lineage",
-      "sub_heading": "related",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "qdes_validate_related_resources ",
-      "field_group": [
-        {
-          "field_name": "resource",
-          "label": "Resource",
-          "form_snippet": "text.html",
-          "form_attrs": {
-            "data-module": "qdes_autocomplete",
-            "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
-            "data-module-create-search-choice": true,
-            "data-module-key": "id",
-            "data-module-label": "title",
-            "class": "form-control"
-          }
-        },
-        {
-          "field_name": "relationship",
-          "label": "Relationship",
-          "form_snippet": "select.html",
-          "choices_helper": "qdes_relationship_types_choices",
-          "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
-        }
-      ]
+      "preset": "related_resources_multi_group"
     },
     {
       "field_name": "lineage_description",

--- a/ckanext/qdes_schema/qdes_dataservice.json
+++ b/ckanext/qdes_schema/qdes_dataservice.json
@@ -197,6 +197,14 @@
       "display_group": "status"
     },
     {
+      "field_name": "related_services",
+      "label": "Related service",
+      "preset": "dataset_related_multi_text"
+    },
+    {
+      "preset": "related_resources_multi_group"
+    },
+    {
       "field_name": "contact_point",
       "label": "Point of contact",
       "display_property": "dcat:contactPoint",

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -61,6 +61,14 @@
       }
     },
     {
+      "preset_name": "qdes_metadata_review_date",
+      "values": {
+        "form_snippet": "qdes_metadata_review_date.html",
+        "display_snippet": "qdes_metadata_review_date.html",
+        "validators": "qdes_validate_metadata_review_date"
+      }
+    },
+    {
       "preset_name": "dataset_related_multi_text",
       "values": {
         "display_group": "related and lineage",
@@ -78,11 +86,40 @@
       }
     },
     {
-      "preset_name": "qdes_metadata_review_date",
+      "preset_name": "related_resources_multi_group",
       "values": {
-        "form_snippet": "qdes_metadata_review_date.html",
-        "display_snippet": "qdes_metadata_review_date.html",
-        "validators": "qdes_validate_metadata_review_date"
+        "field_name": "related_resources",
+        "label": "Related resource",
+        "display_group": "related and lineage",
+        "sub_heading": "related",
+        "form_snippet": "qdes_multi_group.html",
+        "display_snippet": "qdes_multi_group.html",
+        "validators": "qdes_validate_related_resources ",
+        "field_group": [
+          {
+            "field_name": "resource",
+            "label": "Resource",
+            "form_snippet": "text.html",
+            "form_attrs": {
+              "data-module": "qdes_autocomplete",
+              "data-module-source": "/api/2/util/dataset/autocomplete?incomplete=?",
+              "data-module-create-search-choice": true,
+              "data-module-key": "id",
+              "data-module-label": "title",
+              "class": "form-control"
+            }
+          },
+          {
+            "field_name": "relationship",
+            "label": "Relationship",
+            "form_snippet": "select.html",
+            "choices_helper": "qdes_relationship_types_choices",
+            "form_attrs": {
+              "class": "form-control"
+            },
+            "form_include_blank_choice": true
+          }
+        ]
       }
     }
   ]

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
@@ -16,11 +16,12 @@
         placeholder=h.scheming_language_text(field_group.form_placeholder),
         attrs=dict(
             {
-            "data-group": true, 
-            "data-field-name": field_group.field_name, 
-            "data-parent-field-name": field.field_name, 
-            "data-placeholder":"Select a {0}".format(field_group.label),
-            "data-module-id": data.get('id', '')
+                "data-group": true, 
+                "data-field-name": field_group.field_name, 
+                "data-parent-field-name": field.field_name, 
+                "data-placeholder":"Select a {0}".format(field_group.label),
+                "data-module-id": data.get('id', ''),
+                "data-module-type": data.get('type', '')
             }, 
             **(field_group.get('form_attrs', {}))),
         is_required=h.scheming_field_required(field_group),

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
@@ -72,7 +72,7 @@
 {% endcall %}
 {# END: The actual form field the multiple values will be captured & submitted in #}
 
-{% if field.field_name == 'related_resources' and g.controller == 'dataset' and g.action == 'edit' %}
+{% if field.field_name == 'related_resources' and g.controller in ['dataset', 'dataservice'] and g.action == 'edit' %}
     <h4>Existing related resources</h4>
     {% set relationships = h.get_subject_package_relationship_objects(data['id']) %}
     {% if relationships %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
@@ -17,7 +17,14 @@
                         call form.input(
                             label=h.scheming_language_text(field.label),
                             placeholder=h.scheming_language_text(field.form_placeholder),
-                            attrs=dict({"class": "form-control", "data-field-name": field.field_name, "data-placeholder":"Select a {0}".format(field.label)}, **(field.get('form_attrs', {}))),
+                            attrs=dict(
+                                {
+                                    "class": "form-control",
+                                    "data-field-name": field.field_name, 
+                                    "data-placeholder":"Select a {0}".format(field.label),
+                                    "data-module-id": data.get('id', ''),
+                                    "data-module-type": data.get('type', '')
+                                }, **(field.get('form_attrs', {}))),
                             is_required=h.scheming_field_required(field),
                             value=value,
                             error=errors[field.field_name]


### PR DESCRIPTION
- Added new metadata for dataservice 'related_services' and 'related_resources'
- Refactored code for 'related_resources' into new preset 'related_resources_multi_group'
- Added new options for dataset autocomplete to filter on dataset_type and ignore own dataset id
