### PR TITLE
[DDCI-16] Use config for raw query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+.DS_Store

--- a/ckanext/qdes_schema/logic/action/get.py
+++ b/ckanext/qdes_schema/logic/action/get.py
@@ -168,15 +168,18 @@ def all_relationships(context, id):
     """
     Return all relationships with correct order and its nature.
     """
-    # @Todo: Use environment variables for DB connection settings.
     def get_connection():
+        from ckan.model import parse_db_config
+
+        db_config = parse_db_config()
+
         try:
             return psycopg2.connect(
-                user="ckan",
-                password="ckan",
-                host="postgres",
-                port="5432",
-                database="ckan"
+                user=db_config.get('db_user', None),
+                password=db_config.get('db_pass', None),
+                host=db_config.get('db_host', None),
+                port=db_config.get('db_port', "5432") or "5432",
+                database=db_config.get('db_name', None),
             )
         except (Exception, psycopg2.Error) as e:
             log.error(str(e))


### PR DESCRIPTION
- Changed the `all_relationships` function in `ckanext-qdes-schema/ckanext/qdes_schema/logic/action/get.py` to utilise database configuration from the CKAN `.ini` file.