### PR TITLE
Controlled vocabulary - Contacts and responsibilities

### DIFF
--- a/ckanext/qdes_schema/fanstatic/autocomplete.js
+++ b/ckanext/qdes_schema/fanstatic/autocomplete.js
@@ -35,7 +35,8 @@ jQuery(document).ready(function () {
         createSearchChoice: false,
         id: '',
         type: '',
-        vocabularyServiceName: ''
+        vocabularyServiceName: '',
+        minimumInputLength: 0
       },
 
       /* Sets up the module, binding methods, creating elements etc. Called
@@ -61,7 +62,8 @@ jQuery(document).ready(function () {
           dropdownCssClass: this.options.dropdownClass,
           containerCssClass: this.options.containerClass,
           tokenSeparators: this.options.tokensep.split(''),
-          allowClear: this.options.allowClear
+          allowClear: this.options.allowClear,
+          minimumInputLength: this.options.minimumInputLength
         };
 
         // If source is set for API, replace the id placeholder with id passed in

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -78,10 +78,10 @@
     },
     {
       "field_name": "metadata_contact_point",
-      "label": "Point of contact",
+      "label": "Metadata point of contact",
       "display_property": "dcat:contactPoint",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_point",
+      "preset": "qdes_secure_vocab_service_autocomplete",
+      "vocabulary_service_name": "point-of-contact",
       "display_group": "description",
       "form_include_blank_choice": true
     },
@@ -423,11 +423,10 @@
       "field_name": "contact_point",
       "label": "Point of contact",
       "display_property": "dcat:contactPoint",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_point",
+      "preset": "qdes_secure_vocab_service_autocomplete",
+      "vocabulary_service_name": "point-of-contact",
       "display_group": "contacts",
-      "required": true,
-      "form_include_blank_choice": true
+      "required": true
     },
     {
       "field_name": "contact_publisher",
@@ -442,14 +441,19 @@
     {
       "field_name": "contact_creator",
       "label": "Creator",
+      "display_snippet": "text.html",
       "display_property": "dcterms:creator",
-      "preset": "controlled_vocabulary_multi_select",
-      "vocabulary_service_name": "contact_creator",
+      "preset": "qdes_secure_vocab_service_autocomplete",
+      "vocabulary_service_name": "creator",
       "display_group": "contacts",
       "required": false,
-      "form_include_blank_choice": true,
       "form_attrs": {
-        "class": "form-control"
+        "data-module": "qdes_autocomplete",
+        "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+        "data-module-key": "value",
+        "data-module-label": "name",
+        "data-module-minimum-input-length": 3,      
+        "data-module-create-search-choice": true
       }
     },
     {

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -466,14 +466,18 @@
         {
           "field_name": "the-party",
           "label": "The party",
-          "form_snippet": "select.html",
+          "form_snippet": "text.html",
+          "display_snippet": "qdes_secure_vocabulary_text.html",
           "display_property": "prov:agent",
           "vocabulary_service_name": "the-party",
-          "choices_helper": "scheming_vocabulary_service_choices",
           "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
+            "data-module": "qdes_autocomplete",
+            "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+            "data-module-key": "value",
+            "data-module-label": "name",
+            "data-module-minimum-input-length": 3,      
+            "data-module-create-search-choice": true
+          }
         },
         {
           "field_name": "nature-of-their-responsibility",

--- a/ckanext/qdes_schema/qdes_dataservice.json
+++ b/ckanext/qdes_schema/qdes_dataservice.json
@@ -67,10 +67,10 @@
     },
     {
       "field_name": "metadata_contact_point",
-      "label": "Point of contact",
+      "label": "Metadata point of contact",
       "display_property": "dcat:contactPoint",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_point",
+      "preset": "qdes_secure_vocab_service_autocomplete",
+      "vocabulary_service_name": "point-of-contact",
       "display_group": "description",
       "form_include_blank_choice": true
     },
@@ -208,8 +208,6 @@
       "field_name": "contact_point",
       "label": "Point of contact",
       "display_property": "dcat:contactPoint",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "contact_point",
       "display_group": "contacts",
       "required": true,
       "form_include_blank_choice": true

--- a/ckanext/qdes_schema/qdes_dataservice.json
+++ b/ckanext/qdes_schema/qdes_dataservice.json
@@ -245,14 +245,18 @@
         {
           "field_name": "the-party",
           "label": "The party",
-          "form_snippet": "select.html",
+          "form_snippet": "text.html",
+          "display_snippet": "qdes_secure_vocabulary_text.html",
           "display_property": "prov:agent",
           "vocabulary_service_name": "the-party",
-          "choices_helper": "scheming_vocabulary_service_choices",
           "form_attrs": {
-            "class": "form-control"
-          },
-          "form_include_blank_choice": true
+            "data-module": "qdes_autocomplete",
+            "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+            "data-module-key": "value",
+            "data-module-label": "name",
+            "data-module-minimum-input-length": 3,      
+            "data-module-create-search-choice": true
+          }
         },
         {
           "field_name": "nature-of-their-responsibility",

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -150,6 +150,20 @@
           "data-module-label": "name"
         }
       }
+    },
+    {
+      "preset_name": "qdes_secure_vocab_service_autocomplete",
+      "values": {
+        "form_snippet": "text.html",
+        "display_snippet": "qdes_secure_vocabulary_text.html",
+        "form_attrs": {
+          "data-module": "qdes_autocomplete",
+          "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+          "data-module-key": "value",
+          "data-module-label": "name",
+          "data-module-minimum-input-length": 3
+        }
+      }
     }
   ]
 }

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
@@ -1,26 +1,30 @@
 {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 {% for group_data in values  %}
     {% if group_data %}
-        <div>
+        <div class="row">
+            {% set columns = (12 / field.get('field_group')|length)|int %}
             {% for field_group in field.get('field_group') or [] %}
-                {% set value_data = group_data.get(field_group.field_name, '') %}
-                {% set value = value_data.get('text', '')|string if not value_data is string and 'text' in value_data else value_data|string %}
-                {% if h.is_url(value) %}
-                    <a href="{{ value }}"{% if display_property %} property="{{ display_property }}"{% endif %}>
-                        {% if 'choices_helper' in field_group %}
-                            {{ h.scheming_choices_label(h.scheming_field_choices(field_group), value) }}
+                <div class="col-xs-{{columns}}">
+                    {% if '/ckan-admin/vocabulary-services/secure-autocomplete/' in field_group.get('form_attrs', {}).get('data-module-source' ,'') %}
+                        {% snippet "/scheming/display_snippets/qdes_secure_vocabulary_text.html", field=field_group , data=group_data %}
+                    {% else %}
+                        {% set value_data = group_data.get(field_group.field_name, '') %}
+                        {% set value = value_data.get('text', '')|string if not value_data is string and 'text' in value_data else value_data|string %}
+                        {% if h.is_url(value) %}
+                            <a href="{{ value }}"{% if display_property %} property="{{ display_property }}"{% endif %}>
+                                {% if 'choices_helper' in field_group %}
+                                    {{ h.scheming_choices_label(h.scheming_field_choices(field_group), value) }}
+                                {% else %}
+                                    {{ value }}
+                                {% endif %}
+                            </a>
                         {% else %}
-                            {{ value }}
+                            <span {% if field_group.display_property %} property="{{ field_group.display_property }}"{% endif %}>
+                                {{ value }}
+                            </span>
                         {% endif %}
-                    </a>
-                {% else %}
-                    <span {% if field_group.display_property %} property="{{ field_group.display_property }}"{% endif %}>
-                        {{ value }}
-                    </span>
-                {% endif %}
-                {% if not loop.last %}
-                    <span> - </span>
-                {% endif %}
+                    {% endif %}
+                </div>
             {% endfor %}
         </div>
     {% endif %}

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_secure_vocabulary_text.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_secure_vocabulary_text.html
@@ -1,0 +1,11 @@
+<!-- Only display value if user is logged in -->
+{% if g.user and data[field.field_name] and data[field.field_name]|length > 0 %}
+    {% set secure_vocabulary = h.get_secure_vocabulary_record(field.vocabulary_service_name,  data[field.field_name]) %}
+    {% if secure_vocabulary %}
+        {% for key, value in secure_vocabulary.items() %}
+            {{ value}} <br>
+        {% endfor %}
+    {% else %}
+        {{ data[field.field_name] }}
+    {% endif %}  
+{% endif %}

--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_secure_vocabulary_text.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_secure_vocabulary_text.html
@@ -3,7 +3,10 @@
     {% set secure_vocabulary = h.get_secure_vocabulary_record(field.vocabulary_service_name,  data[field.field_name]) %}
     {% if secure_vocabulary %}
         {% for key, value in secure_vocabulary.items() %}
-            {{ value}} <br>
+            <div>{{ value }}</div>
+            {% if not loop.last %}
+                <hr>
+            {% endif %} 
         {% endfor %}
     {% else %}
         {{ data[field.field_name] }}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/field_groups/text.html
@@ -9,6 +9,10 @@
         <!-- If value is from vocabulary term autocomplete, create json object -->
         {% elif '/ckan-admin/vocabulary-service/term-autocomplete/' in field_group.get('form_attrs', {}).get('data-module-source' ,'') %}
             {% set value = h.dump_json({"id": value, "text":  h.scheming_choices_label(h.scheming_field_choices(field_group), value)}) %}
+        <!-- If value is from vocabulary secure record autocomplete, create json object -->
+        {% elif '/ckan-admin/vocabulary-services/secure-autocomplete/' in field_group.get('form_attrs', {}).get('data-module-source' ,'') %}
+            {% set text = h.get_secure_vocabulary_record_label(field_group.vocabulary_service_name, value) %}
+            {% set value = h.dump_json({"id": value, "text":  text}) %}
         {% endif %}
     {% endif %}
 {%- else -%}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/text.html
@@ -10,8 +10,8 @@
         {% elif '/ckan-admin/vocabulary-service/term-autocomplete/' in field.get('form_attrs', {}).get('data-module-source' ,'')%}
             {% set value = h.dump_json({"id": value, "text":  h.scheming_choices_label(h.scheming_field_choices(field), value)}) %}
         <!-- If value is from vocabulary secure record autocomplete, create json object -->
-        {% elif '/ckan-admin/vocabulary-services/secure-autocomplete/' in field.get('form_attrs', {}).get('data-module-source' ,'')%}
-            {% set text = h.get_secure_vocabulary_record_label(field.vocabulary_service_name, data[field.field_name]) if h.get_secure_vocabulary_lookup_field(field.vocabulary_service_name) else value %}
+        {% elif '/ckan-admin/vocabulary-services/secure-autocomplete/' in field.get('form_attrs', {}).get('data-module-source' ,'') %}
+            {% set text = h.get_secure_vocabulary_record_label(field.vocabulary_service_name, value) %}
             {% set value = h.dump_json({"id": value, "text":  text}) %}
         {% endif %}
     {% endif %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/text.html
@@ -9,6 +9,10 @@
         <!-- If value is from vocabulary term autocomplete, create json object -->
         {% elif '/ckan-admin/vocabulary-service/term-autocomplete/' in field.get('form_attrs', {}).get('data-module-source' ,'')%}
             {% set value = h.dump_json({"id": value, "text":  h.scheming_choices_label(h.scheming_field_choices(field), value)}) %}
+        <!-- If value is from vocabulary secure record autocomplete, create json object -->
+        {% elif '/ckan-admin/vocabulary-services/secure-autocomplete/' in field.get('form_attrs', {}).get('data-module-source' ,'')%}
+            {% set text = h.get_secure_vocabulary_record_label(field.vocabulary_service_name, data[field.field_name]) if h.get_secure_vocabulary_lookup_field(field.vocabulary_service_name) else value %}
+            {% set value = h.dump_json({"id": value, "text":  text}) %}
         {% endif %}
     {% endif %}
 {%- else -%}


### PR DESCRIPTION
This PR includes the following stories:
https://it-partners.atlassian.net/browse/DDCI-41
https://it-partners.atlassian.net/browse/DDCI-43
https://it-partners.atlassian.net/browse/DDCI-215

- Added new preset for 'qdes_secure_vocab_service_autocomplete'
- Added new preset to field 'contact_point'
- Added new display snippet for 'qdes_secure_vocabulary_text.html'
- Added minimumInputLength to 'autocomplete.js'