### PR TITLE
[DDCI-96] Adjusted `related_datasets` blueprint function

### DIFF
--- a/ckanext/qdes_schema/blueprint.py
+++ b/ckanext/qdes_schema/blueprint.py
@@ -20,18 +20,22 @@ render = toolkit.render
 qdes_schema = Blueprint('qdes_schema', __name__)
 
 
-def related_datasets(id):
+def related_datasets(name_or_id):
     try:
         related = []
-        all_relationships = helpers.get_all_relationships(id)
+
+        pkg_dict = get_action('package_show')({}, {'id': name_or_id})
+
+        all_relationships = helpers.get_all_relationships(pkg_dict['id'])
 
         for relationship in all_relationships:
             if relationship.get('type') not in ['isPartOf', 'hasPart']:
                 related.append(relationship)
 
-        extra_vars = {}
-        extra_vars['pkg_dict'] = get_action('package_show')({}, {'id': id})
-        extra_vars['related'] = related
+        extra_vars = {
+            'pkg_dict': pkg_dict,
+            'related': related
+        }
 
         return render('package/related_datasets.html', extra_vars=extra_vars)
     except (NotFound, NotAuthorized):
@@ -84,7 +88,7 @@ def datasets_available(id):
         abort(404, _('Available datasets not found'))
 
 
-qdes_schema.add_url_rule(u'/dataset/<id>/related-datasets', view_func=related_datasets)
+qdes_schema.add_url_rule(u'/dataset/<name_or_id>/related-datasets', view_func=related_datasets)
 qdes_schema.add_url_rule(u'/dataset/<id>/metadata', view_func=dataset_metadata)
 qdes_schema.add_url_rule(u'/dataservice/<id>/metadata', endpoint='dataservice_metadata', view_func=dataset_metadata)
 qdes_schema.add_url_rule(u'/dataset/<id>/resource/<resource_id>/metadata', view_func=resource_metadata)


### PR DESCRIPTION
- The `related_datasets` blueprint function was expecting `id` to be a CKAN UUID but it can also be passed a CKAN package.name
- This change allows the function to accept either and does the `package_show` lookup first before continuing