### PR TITLE
[DDCI-232] - prevented multiple resourse to be added when clicking previous btn

### DIFF
--- a/ckanext/qdes_schema/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/resource_form.html
@@ -45,3 +45,7 @@
 
 {% block metadata_fields %}
 {% endblock %}
+
+{% block previous_button %}
+  <a class="btn btn-default" href="{{h.url_for(dataset_type ~ '.edit', id=pkg_name)}}">{{ _('Previous') }}</a>
+{% endblock %}


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-232

The issue:
in file `ckan/ckan_core/ckan/views/resource.py:203`, the `data_provided` variable is always return True.
so that the conditional statement on 211 never executed.

the code then jump to 248, the try catch block, here either create or update resource, and it is always create.

since this is on the core ckan, it maybe built like this?


the workaround, I added a custom button with a link back to the edit package.
