### PR TITLE
[DDCI-210] - removed tooltip from vocab autocomplete

### DIFF
--- a/ckanext/qdes_schema/fanstatic/autocomplete.js
+++ b/ckanext/qdes_schema/fanstatic/autocomplete.js
@@ -120,6 +120,10 @@ jQuery(document).ready(function () {
           return false;
         });
 
+        this.el.on('select2-selecting', function (e) {
+            $('.tooltip').remove();
+        });
+
         this._select2 = select2;
       },
 

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -84,10 +84,7 @@
       "preset": "qdes_secure_vocab_service_autocomplete",
       "vocabulary_service_name": "point-of-contact",
       "display_group": "description",
-      "form_include_blank_choice": true,
-      "form_attrs": {
-        "data-module-title": "title"
-      }
+      "form_include_blank_choice": true
     },
     {
       "field_name": "url",
@@ -452,10 +449,7 @@
       "preset": "qdes_secure_vocab_service_autocomplete",
       "vocabulary_service_name": "point-of-contact",
       "display_group": "contacts",
-      "required": true,
-      "form_attrs": {
-        "data-module-title": "title"
-      }
+      "required": true
     },
     {
       "field_name": "contact_publisher",
@@ -668,6 +662,10 @@
       "vocabulary_service_name": "format",
       "required": true,
       "form_attrs": {
+        "data-module": "qdes_autocomplete",
+        "data-module-source": "/ckan-admin/vocabulary-service/term-autocomplete/format?incomplete=?",
+        "data-module-key": "value",
+        "data-module-label": "name",
         "data-module-title": "title"
       }
     },


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-210

@MarkCalvert this to remove tooltips on secure vocab. also, it fixes the issue where the tooltip still visible after we select the option.