### PR TITLE
[DDCI-139] - fix anchor issues for repeater field

### DIFF
--- a/ckanext/qdes_schema/dataqld_dataset.json
+++ b/ckanext/qdes_schema/dataqld_dataset.json
@@ -537,7 +537,8 @@
       "display_group": "status",
       "form_attrs": {
         "data-module-title": "title"
-      }
+      },
+      "form_include_blank_choice": true
     },
     {
       "field_name": "dataset_creation_date",

--- a/ckanext/qdes_schema/dataqld_dataset.json
+++ b/ckanext/qdes_schema/dataqld_dataset.json
@@ -250,7 +250,8 @@
       "form_snippet": "qdes_multi_text.html",
       "validators": "ignore_missing qdes_uri_validator",
       "display_property": "dcterms:conformsTo",
-      "display_group": "data quality"
+      "display_group": "data quality",
+      "recommended": true
     },
     {
       "field_name": "quality_description",

--- a/ckanext/qdes_schema/dataqld_dataset.json
+++ b/ckanext/qdes_schema/dataqld_dataset.json
@@ -380,7 +380,8 @@
       "preset": "dataset_related_multi_text"
     },
     {
-      "preset": "related_resources_multi_group"
+      "preset": "related_resources_multi_group",
+      "validators": "ignore_missing"
     },
     {
       "field_name": "lineage_description",

--- a/ckanext/qdes_schema/dataqld_dataset.json
+++ b/ckanext/qdes_schema/dataqld_dataset.json
@@ -202,6 +202,19 @@
       }
     },
     {
+      "field_name": "spatial_name_code",
+      "label": "Name or code",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_name_code",
+      "form_attrs": {
+        "data-module": "qdes_autocomplete",
+        "data-module-title": "title"
+      },
+      "display_property": "dcterms:spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "form_snippet": "textarea.html",
@@ -242,7 +255,53 @@
       "label": "Spatial resolution in meters",
       "validators": "ignore_missing qdes_validate_decimal",
       "display_property": "dcat:spatialResolutionInMeters",
-      "display_group": "spatial content"
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial",
+      "label": "Spatial",
+      "preset": "json_object",
+      "form_snippet": "qdes_hidden_json.html",
+      "validators": "ignore_missing qdes_validate_geojson_spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_representation",
+      "label": "Representation",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_representation",
+      "display_property": "qdcat:hasSpatialRepresentation",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
+    },
+    {
+      "field_name": "spatial_datum_crs",
+      "label": "Datum & CRS",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_datum_crs",
+      "display_property": "qeox:inCRS",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
+    },
+    {
+      "field_name": "spatial_resolution",
+      "label": "Resolution",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_resolution",
+      "display_property": "qdcat:spatialResolution",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
     },
     {
       "field_name": "conforms_to",
@@ -253,6 +312,37 @@
       "display_property": "dcterms:conformsTo",
       "display_group": "data quality",
       "recommended": true
+    },
+    {
+      "field_name": "quality_measure",
+      "label": "Quality measure",
+      "display_group": "data quality",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_multi_groups",
+      "field_group": [
+        {
+          "field_name": "measurement",
+          "label": "Measurement",
+          "preset": "controlled_vocabulary_single_select",
+          "form_snippet": "select.html",
+          "display_snippet": "controlled_vocabulary_single_select.html",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "vocabulary_service_name": "measurement",
+          "form_attrs": {
+            "class": "form-control",
+            "data-module-title": "title"
+          }
+        },
+        {
+          "field_name": "value",
+          "label": "Value",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "class": "form-control"
+          }
+        }
+      ]
     },
     {
       "field_name": "quality_description",
@@ -281,90 +371,6 @@
           "label": "Value",
           "form_snippet": "text.html",
           "display_property": "oa:bodyValue",
-          "form_attrs": {
-            "class": "form-control"
-          }
-        }
-      ]
-    },
-    {
-      "field_name": "spatial",
-      "label": "Spatial",
-      "preset": "json_object",
-      "form_snippet": "qdes_hidden_json.html",
-      "validators": "ignore_missing qdes_validate_geojson_spatial",
-      "display_group": "spatial content"
-    },
-    {
-      "field_name": "spatial_name_code",
-      "label": "Name or code",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_name_code",
-      "form_attrs": {
-        "data-module": "qdes_autocomplete",
-        "data-module-title": "title"
-      },
-      "display_property": "dcterms:spatial",
-      "display_group": "spatial coverage"
-    },
-    {
-      "field_name": "spatial_representation",
-      "label": "Representation",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_representation",
-      "display_property": "qdcat:hasSpatialRepresentation",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "spatial_datum_crs",
-      "label": "Datum & CRS",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_datum_crs",
-      "display_property": "qeox:inCRS",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "spatial_resolution",
-      "label": "Resolution",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_resolution",
-      "display_property": "qdcat:spatialResolution",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "quality_measure",
-      "label": "Quality measure",
-      "display_group": "data quality",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "ignore_empty qdes_validate_multi_groups",
-      "field_group": [
-        {
-          "field_name": "measurement",
-          "label": "Measurement",
-          "preset": "controlled_vocabulary_single_select",
-          "form_snippet": "select.html",
-          "display_snippet": "controlled_vocabulary_single_select.html",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "vocabulary_service_name": "measurement",
-          "form_attrs": {
-            "class": "form-control",
-            "data-module-title": "title"
-          }
-        },
-        {
-          "field_name": "value",
-          "label": "Value",
-          "form_snippet": "text.html",
           "form_attrs": {
             "class": "form-control"
           }

--- a/ckanext/qdes_schema/dataqld_dataset.json
+++ b/ckanext/qdes_schema/dataqld_dataset.json
@@ -10,7 +10,8 @@
       "preset": "title",
       "form_placeholder": "eg. A descriptive title",
       "display_group": "general",
-      "required": true
+      "required": true,
+      "validators": "scheming_required"
     },
     {
       "field_name": "name",

--- a/ckanext/qdes_schema/fanstatic/iso-8601-duration.js
+++ b/ckanext/qdes_schema/fanstatic/iso-8601-duration.js
@@ -121,7 +121,7 @@
         $(document).on('blur', '.iso-8601-duration-field input', function () {
             var $wrapper = $(this).parents('.iso-8601-duration-field-wrapper');
             var field_name = $wrapper.data('duration-fieldname');
-            var $el = $wrapper.find('#field-' + field_name);
+            var $el = $wrapper.find('#field-' + field_name + '-hidden');
             var current_designator = $(this).attr('name').replace(field_name + '_', '');
 
             setDesignator(duration_field_designators[field_name], current_designator, $(this).val());
@@ -134,7 +134,7 @@
         $('.iso-8601-duration-field-wrapper').each(function () {
             var $el_wrapper = $(this);
             var field_name = $el_wrapper.data('duration-fieldname');
-            var $el = $el_wrapper.find('#field-' + field_name);
+            var $el = $el_wrapper.find('#field-' + field_name + '-hidden');
 
             if (field_name.length > 0) {
                 // Parse the duration and put them to respected field.

--- a/ckanext/qdes_schema/fanstatic/repeating-fields.js
+++ b/ckanext/qdes_schema/fanstatic/repeating-fields.js
@@ -140,7 +140,7 @@ jQuery(document).ready(function () {
         var target_field_id = parent_field_name ? 'field-' + parent_field_name : 'field-' + field_name;
         var field_type = jQuery('#' + repeater_id).data('field-type');
 
-        collate_inputs(repeater_id, target_field_id, field_type);
+        collate_inputs(repeater_id, target_field_id + '-hidden', field_type);
         related_resource_replaces_relationship(element);
     }
 

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -183,7 +183,7 @@
       "label": "Temporal coverage end",
       "display_property": "dcat:endDate",
       "preset": "date",
-      "validators": "ignore_missing qdes_temporal_start_end_date",
+      "validators": "qdes_temporal_start_end_date",
       "display_group": "temporal content",
       "sub_heading": "temporal coverage"
     },

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -9,7 +9,9 @@
       "label": "Title",
       "preset": "title",
       "form_placeholder": "eg. A descriptive title",
-      "display_group": "general"
+      "display_group": "general",
+      "required": true,
+      "validators": "scheming_required if_empty_same_as(name) unicode"
     },
     {
       "field_name": "name",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -205,6 +205,19 @@
       }
     },
     {
+      "field_name": "spatial_name_code",
+      "label": "Name or code",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_name_code",
+      "form_attrs": {
+        "data-module": "qdes_autocomplete",
+        "data-module-title": "title"
+      },
+      "display_property": "dcterms:spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "form_snippet": "textarea.html",
@@ -248,6 +261,50 @@
       "display_group": "spatial content"
     },
     {
+      "field_name": "spatial",
+      "label": "Spatial",
+      "preset": "json_object",
+      "form_snippet": "qdes_hidden_json.html",
+      "validators": "ignore_missing qdes_validate_geojson_spatial",
+      "display_group": "spatial content"
+    },
+    {
+      "field_name": "spatial_representation",
+      "label": "Representation",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_representation",
+      "display_property": "qdcat:hasSpatialRepresentation",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
+    },
+    {
+      "field_name": "spatial_datum_crs",
+      "label": "Datum & CRS",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_datum_crs",
+      "display_property": "qeox:inCRS",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
+    },
+    {
+      "field_name": "spatial_resolution",
+      "label": "Resolution",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_resolution",
+      "display_property": "qdcat:spatialResolution",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      }
+    },
+    {
       "field_name": "conforms_to",
       "label": "Schema or standard",
       "display_snippet": "qdes_multi_text_url.html",
@@ -256,6 +313,37 @@
       "display_property": "dcterms:conformsTo",
       "display_group": "data quality",
       "recommended": true
+    },
+    {
+      "field_name": "quality_measure",
+      "label": "Quality measure",
+      "display_group": "data quality",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_multi_groups",
+      "field_group": [
+        {
+          "field_name": "measurement",
+          "label": "Measurement",
+          "preset": "controlled_vocabulary_single_select",
+          "form_snippet": "select.html",
+          "display_snippet": "controlled_vocabulary_single_select.html",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "vocabulary_service_name": "measurement",
+          "form_attrs": {
+            "class": "form-control",
+            "data-module-title": "title"
+          }
+        },
+        {
+          "field_name": "value",
+          "label": "Value",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "class": "form-control"
+          }
+        }
+      ]
     },
     {
       "field_name": "quality_description",
@@ -284,90 +372,6 @@
           "label": "Value",
           "form_snippet": "text.html",
           "display_property": "oa:bodyValue",
-          "form_attrs": {
-            "class": "form-control"
-          }
-        }
-      ]
-    },
-    {
-      "field_name": "spatial",
-      "label": "Spatial",
-      "preset": "json_object",
-      "form_snippet": "qdes_hidden_json.html",
-      "validators": "ignore_missing qdes_validate_geojson_spatial",
-      "display_group": "spatial content"
-    },
-    {
-      "field_name": "spatial_name_code",
-      "label": "Name or code",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_name_code",
-      "form_attrs": {
-        "data-module": "qdes_autocomplete",
-        "data-module-title": "title"
-      },
-      "display_property": "dcterms:spatial",
-      "display_group": "spatial coverage"
-    },
-    {
-      "field_name": "spatial_representation",
-      "label": "Representation",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_representation",
-      "display_property": "qdcat:hasSpatialRepresentation",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "spatial_datum_crs",
-      "label": "Datum & CRS",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_datum_crs",
-      "display_property": "qeox:inCRS",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "spatial_resolution",
-      "label": "Resolution",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_resolution",
-      "display_property": "qdcat:spatialResolution",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      }
-    },
-    {
-      "field_name": "quality_measure",
-      "label": "Quality measure",
-      "display_group": "data quality",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "ignore_empty qdes_validate_multi_groups",
-      "field_group": [
-        {
-          "field_name": "measurement",
-          "label": "Measurement",
-          "preset": "controlled_vocabulary_single_select",
-          "form_snippet": "select.html",
-          "display_snippet": "controlled_vocabulary_single_select.html",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "vocabulary_service_name": "measurement",
-          "form_attrs": {
-            "class": "form-control",
-            "data-module-title": "title"
-          }
-        },
-        {
-          "field_name": "value",
-          "label": "Value",
-          "form_snippet": "text.html",
           "form_attrs": {
             "class": "form-control"
           }

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -252,7 +252,8 @@
       "form_snippet": "qdes_multi_text.html",
       "validators": "ignore_missing qdes_uri_validator",
       "display_property": "dcterms:conformsTo",
-      "display_group": "data quality"
+      "display_group": "data quality",
+      "recommended": true
     },
     {
       "field_name": "quality_description",

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -543,7 +543,8 @@
       "required": true,
       "form_attrs": {
         "data-module-title": "title"
-      }
+      },
+      "form_include_blank_choice": true
     },
     {
       "field_name": "dataset_creation_date",

--- a/ckanext/qdes_schema/qdes_dataservice.json
+++ b/ckanext/qdes_schema/qdes_dataservice.json
@@ -9,7 +9,9 @@
       "label": "Title",
       "preset": "title",
       "form_placeholder": "eg. A descriptive title",
-      "display_group": "general"
+      "display_group": "general",
+      "required": true,
+      "validators": "scheming_required if_empty_same_as(name) unicode"
     },
     {
       "field_name": "name",

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -65,7 +65,7 @@
       "values": {
         "form_snippet": "qdes_metadata_review_date.html",
         "display_snippet": "qdes_metadata_review_date.html",
-        "validators": "ignore_missing qdes_validate_metadata_review_date"
+        "validators": "qdes_validate_metadata_review_date"
       }
     },
     {

--- a/ckanext/qdes_schema/qspatial_dataset.json
+++ b/ckanext/qdes_schema/qspatial_dataset.json
@@ -261,7 +261,8 @@
       "form_snippet": "qdes_multi_text.html",
       "validators": "ignore_missing qdes_uri_validator",
       "display_property": "dcterms:conformsTo",
-      "display_group": "data quality"
+      "display_group": "data quality",
+      "recommended": true
     },
     {
       "field_name": "quality_description",

--- a/ckanext/qdes_schema/qspatial_dataset.json
+++ b/ckanext/qdes_schema/qspatial_dataset.json
@@ -211,6 +211,19 @@
       }
     },
     {
+      "field_name": "spatial_name_code",
+      "label": "Name or code",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_name_code",
+      "form_attrs": {
+        "data-module": "qdes_autocomplete",
+        "data-module-title": "title"
+      },
+      "display_property": "dcterms:spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "form_snippet": "textarea.html",
@@ -253,7 +266,56 @@
       "label": "Spatial resolution in meters",
       "validators": "ignore_missing qdes_validate_decimal",
       "display_property": "dcat:spatialResolutionInMeters",
-      "display_group": "spatial content"
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial",
+      "label": "Spatial",
+      "preset": "json_object",
+      "form_snippet": "qdes_hidden_json.html",
+      "validators": "ignore_missing qdes_validate_geojson_spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
+      "field_name": "spatial_representation",
+      "label": "Representation",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_representation",
+      "display_property": "qdcat:hasSpatialRepresentation",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      },
+      "required": true
+    },
+    {
+      "field_name": "spatial_datum_crs",
+      "label": "Datum & CRS",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_datum_crs",
+      "display_property": "qeox:inCRS",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      },
+      "required": true
+    },
+    {
+      "field_name": "spatial_resolution",
+      "label": "Resolution",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_resolution",
+      "display_property": "qdcat:spatialResolution",
+      "display_group": "spatial content",
+      "sub_heading": "spatial details",
+      "form_attrs": {
+        "data-module-title": "title"
+      },
+      "required": true
     },
     {
       "field_name": "conforms_to",
@@ -264,6 +326,37 @@
       "display_property": "dcterms:conformsTo",
       "display_group": "data quality",
       "recommended": true
+    },
+    {
+      "field_name": "quality_measure",
+      "label": "Quality measure",
+      "display_group": "data quality",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_multi_groups",
+      "field_group": [
+        {
+          "field_name": "measurement",
+          "label": "Measurement",
+          "preset": "controlled_vocabulary_single_select",
+          "form_snippet": "select.html",
+          "display_snippet": "controlled_vocabulary_single_select.html",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "vocabulary_service_name": "measurement",
+          "form_attrs": {
+            "class": "form-control",
+            "data-module-title": "title"
+          }
+        },
+        {
+          "field_name": "value",
+          "label": "Value",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "class": "form-control"
+          }
+        }
+      ]
     },
     {
       "field_name": "quality_description",
@@ -293,93 +386,6 @@
           "label": "Value",
           "form_snippet": "text.html",
           "display_property": "oa:bodyValue",
-          "form_attrs": {
-            "class": "form-control"
-          }
-        }
-      ]
-    },
-    {
-      "field_name": "spatial",
-      "label": "Spatial",
-      "preset": "json_object",
-      "form_snippet": "qdes_hidden_json.html",
-      "validators": "ignore_missing qdes_validate_geojson_spatial",
-      "display_group": "spatial content"
-    },
-    {
-      "field_name": "spatial_name_code",
-      "label": "Name or code",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_name_code",
-      "form_attrs": {
-        "data-module": "qdes_autocomplete",
-        "data-module-title": "title"
-      },
-      "display_property": "dcterms:spatial",
-      "display_group": "spatial coverage"
-    },
-    {
-      "field_name": "spatial_representation",
-      "label": "Representation",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_representation",
-      "display_property": "qdcat:hasSpatialRepresentation",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      },
-      "required": true
-    },
-    {
-      "field_name": "spatial_datum_crs",
-      "label": "Datum & CRS",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_datum_crs",
-      "display_property": "qeox:inCRS",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      },
-      "required": true
-    },
-    {
-      "field_name": "spatial_resolution",
-      "label": "Resolution",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_resolution",
-      "display_property": "qdcat:spatialResolution",
-      "display_group": "spatial details",
-      "form_attrs": {
-        "data-module-title": "title"
-      },
-      "required": true
-    },
-    {
-      "field_name": "quality_measure",
-      "label": "Quality measure",
-      "display_group": "data quality",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "ignore_empty qdes_validate_multi_groups",
-      "field_group": [
-        {
-          "field_name": "measurement",
-          "label": "Measurement",
-          "preset": "controlled_vocabulary_single_select",
-          "form_snippet": "select.html",
-          "display_snippet": "controlled_vocabulary_single_select.html",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "vocabulary_service_name": "measurement",
-          "form_attrs": {
-            "class": "form-control",
-            "data-module-title": "title"
-          }
-        },
-        {
-          "field_name": "value",
-          "label": "Value",
-          "form_snippet": "text.html",
           "form_attrs": {
             "class": "form-control"
           }

--- a/ckanext/qdes_schema/qspatial_dataset.json
+++ b/ckanext/qdes_schema/qspatial_dataset.json
@@ -395,7 +395,8 @@
       "preset": "dataset_related_multi_text"
     },
     {
-      "preset": "related_resources_multi_group"
+      "preset": "related_resources_multi_group",
+      "validators": "ignore_missing"
     },
     {
       "field_name": "lineage_description",

--- a/ckanext/qdes_schema/qspatial_dataset.json
+++ b/ckanext/qdes_schema/qspatial_dataset.json
@@ -557,7 +557,8 @@
       "required": true,
       "form_attrs": {
         "data-module-title": "title"
-      }
+      },
+      "form_include_blank_choice": true
     },
     {
       "field_name": "dataset_creation_date",

--- a/ckanext/qdes_schema/qspatial_dataset.json
+++ b/ckanext/qdes_schema/qspatial_dataset.json
@@ -10,7 +10,8 @@
       "preset": "title",
       "form_placeholder": "eg. A descriptive title",
       "display_group": "general",
-      "required": true
+      "required": true,
+      "validators": "scheming_required"
     },
     {
       "field_name": "name",

--- a/ckanext/qdes_schema/sir_dataset.json
+++ b/ckanext/qdes_schema/sir_dataset.json
@@ -247,7 +247,8 @@
       "form_snippet": "qdes_multi_text.html",
       "validators": "ignore_missing qdes_uri_validator",
       "display_property": "dcterms:conformsTo",
-      "display_group": "data quality"
+      "display_group": "data quality",
+      "recommended": true
     },
     {
       "field_name": "quality_description",

--- a/ckanext/qdes_schema/sir_dataset.json
+++ b/ckanext/qdes_schema/sir_dataset.json
@@ -534,7 +534,8 @@
       "display_group": "status",
       "form_attrs": {
         "data-module-title": "title"
-      }
+      },
+      "form_include_blank_choice": true
     },
     {
       "field_name": "dataset_creation_date",

--- a/ckanext/qdes_schema/sir_dataset.json
+++ b/ckanext/qdes_schema/sir_dataset.json
@@ -377,7 +377,8 @@
       "preset": "dataset_related_multi_text"
     },
     {
-      "preset": "related_resources_multi_group"
+      "preset": "related_resources_multi_group",
+      "validators": "ignore_missing"
     },
     {
       "field_name": "lineage_description",

--- a/ckanext/qdes_schema/sir_dataset.json
+++ b/ckanext/qdes_schema/sir_dataset.json
@@ -199,6 +199,19 @@
       }
     },
     {
+      "field_name": "spatial_name_code",
+      "label": "Name or code",
+      "preset": "controlled_vocabulary_single_select",
+      "vocabulary_service_name": "spatial_name_code",
+      "form_attrs": {
+        "data-module": "qdes_autocomplete",
+        "data-module-title": "title"
+      },
+      "display_property": "dcterms:spatial",
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
+    },
+    {
       "field_name": "spatial_lower_left",
       "label": "Lower left",
       "form_snippet": "textarea.html",
@@ -239,50 +252,8 @@
       "label": "Spatial resolution in meters",
       "validators": "ignore_missing qdes_validate_decimal",
       "display_property": "dcat:spatialResolutionInMeters",
-      "display_group": "spatial content"
-    },
-    {
-      "field_name": "conforms_to",
-      "label": "Schema or standard",
-      "display_snippet": "qdes_multi_text_url.html",
-      "form_snippet": "qdes_multi_text.html",
-      "validators": "ignore_missing qdes_uri_validator",
-      "display_property": "dcterms:conformsTo",
-      "display_group": "data quality",
-      "recommended": true
-    },
-    {
-      "field_name": "quality_description",
-      "label": "Quality description",
-      "display_group": "data quality",
-      "form_snippet": "qdes_multi_group.html",
-      "display_snippet": "qdes_multi_group.html",
-      "validators": "ignore_empty qdes_validate_multi_groups",
-      "field_group": [
-        {
-          "field_name": "dimension",
-          "label": "Dimension",
-          "display_property": "dqv:inDimension",
-          "preset": "controlled_vocabulary_single_select",
-          "form_snippet": "select.html",
-          "display_snippet": "controlled_vocabulary_single_select.html",
-          "choices_helper": "scheming_vocabulary_service_choices",
-          "vocabulary_service_name": "dimension",
-          "form_attrs": {
-            "class": "form-control",
-            "data-module-title": "title"
-          }
-        },
-        {
-          "field_name": "value",
-          "label": "Value",
-          "form_snippet": "text.html",
-          "display_property": "oa:bodyValue",
-          "form_attrs": {
-            "class": "form-control"
-          }
-        }
-      ]
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
     },
     {
       "field_name": "spatial",
@@ -290,19 +261,8 @@
       "preset": "json_object",
       "form_snippet": "qdes_hidden_json.html",
       "validators": "ignore_missing qdes_validate_geojson_spatial",
-      "display_group": "spatial content"
-    },
-    {
-      "field_name": "spatial_name_code",
-      "label": "Name or code",
-      "preset": "controlled_vocabulary_single_select",
-      "vocabulary_service_name": "spatial_name_code",
-      "form_attrs": {
-        "data-module": "qdes_autocomplete",
-        "data-module-title": "title"
-      },
-      "display_property": "dcterms:spatial",
-      "display_group": "spatial coverage"
+      "display_group": "spatial content",
+      "sub_heading": "spatial coverage"
     },
     {
       "field_name": "spatial_representation",
@@ -336,6 +296,80 @@
       "form_attrs": {
         "data-module-title": "title"
       }
+    },
+    {
+      "field_name": "conforms_to",
+      "label": "Schema or standard",
+      "display_snippet": "qdes_multi_text_url.html",
+      "form_snippet": "qdes_multi_text.html",
+      "validators": "ignore_missing qdes_uri_validator",
+      "display_property": "dcterms:conformsTo",
+      "display_group": "data quality",
+      "recommended": true
+    },
+    {
+      "field_name": "quality_measure",
+      "label": "Quality measure",
+      "display_group": "data quality",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_multi_groups",
+      "field_group": [
+        {
+          "field_name": "measurement",
+          "label": "Measurement",
+          "preset": "controlled_vocabulary_single_select",
+          "form_snippet": "select.html",
+          "display_snippet": "controlled_vocabulary_single_select.html",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "vocabulary_service_name": "measurement",
+          "form_attrs": {
+            "class": "form-control",
+            "data-module-title": "title"
+          }
+        },
+        {
+          "field_name": "value",
+          "label": "Value",
+          "form_snippet": "text.html",
+          "form_attrs": {
+            "class": "form-control"
+          }
+        }
+      ]
+    },
+    {
+      "field_name": "quality_description",
+      "label": "Quality description",
+      "display_group": "data quality",
+      "form_snippet": "qdes_multi_group.html",
+      "display_snippet": "qdes_multi_group.html",
+      "validators": "ignore_empty qdes_validate_multi_groups",
+      "field_group": [
+        {
+          "field_name": "dimension",
+          "label": "Dimension",
+          "display_property": "dqv:inDimension",
+          "preset": "controlled_vocabulary_single_select",
+          "form_snippet": "select.html",
+          "display_snippet": "controlled_vocabulary_single_select.html",
+          "choices_helper": "scheming_vocabulary_service_choices",
+          "vocabulary_service_name": "dimension",
+          "form_attrs": {
+            "class": "form-control",
+            "data-module-title": "title"
+          }
+        },
+        {
+          "field_name": "value",
+          "label": "Value",
+          "form_snippet": "text.html",
+          "display_property": "oa:bodyValue",
+          "form_attrs": {
+            "class": "form-control"
+          }
+        }
+      ]
     },
     {
       "field_name": "quality_measure",

--- a/ckanext/qdes_schema/sir_dataset.json
+++ b/ckanext/qdes_schema/sir_dataset.json
@@ -10,7 +10,8 @@
       "preset": "title",
       "form_placeholder": "eg. A descriptive title",
       "display_group": "general",
-      "required": true
+      "required": true,
+      "validators": "scheming_required"
     },
     {
       "field_name": "name",

--- a/ckanext/qdes_schema/templates/package/metadata.html
+++ b/ckanext/qdes_schema/templates/package/metadata.html
@@ -22,8 +22,13 @@
                 </th>
                 <td class="dataset-details"{%
                   if field.display_property %} property="{{ field.display_property
-                  }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
-                  field=field, data=pkg_dict, schema=schema -%}</td>
+                  }}"{% endif %}>
+                  {%- if field.field_name == 'owner_org' -%}
+                    {{ pkg_dict['organization']['title'] }}
+                  {%- else -%}
+                    {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
+                  {%- endif -%}
+                </td>
               </tr>
             {%- endif -%}
           {%- endfor -%}

--- a/ckanext/qdes_schema/templates/package/schema_validation.html
+++ b/ckanext/qdes_schema/templates/package/schema_validation.html
@@ -34,7 +34,7 @@
         <ul>
           {% for key, error in pkg_errors.items() %}
             <li>
-              <a href="{{ h.url_for('dataset.edit', id=pkg_dict.id) }}#field-{{key}}">
+              <a target="_blank" href="{{ h.url_for('dataset.edit', id=pkg_dict.id) }}#field-{{key}}">
                 <strong>{{ h.qdes_get_field_label(key, schema) }}</strong></a> : {{ error|join(', ') }}
             </li>
           {% endfor %}
@@ -55,7 +55,7 @@
             {% for err in res.errors %}
               {% for key, key_error in err.items() %}
                 <li>
-                  <a href="{{ h.url_for(pkg_dict.type + '_resource.edit', id=pkg_dict.id, resource_id=res.resource_id) }}#field-{{key}}">
+                  <a target="_blank" href="{{ h.url_for(pkg_dict.type + '_resource.edit', id=pkg_dict.id, resource_id=res.resource_id) }}#field-{{key}}">
                     <strong>{{ h.qdes_get_field_label(key, schema, 'resource_fields') }}</strong></a> : {{ key_error|join(', ') }}
                 </li>
               {% endfor %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/datetime_tz.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/datetime_tz.html
@@ -21,7 +21,7 @@
     {% endif %}
 {% endif %}
 
-<div class="row">
+<div class="row" id="field-{{ field.field_name }}">
     {% call form.input(
         field.field_name + '_date',
         id='field-' + field.field_name +  '-date',

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_duration.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_duration.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
 
-<div class="iso-8601-duration-field-wrapper" data-duration-fieldname="{{ field.field_name }}">
+<div id="{{ 'field-' + field.field_name }}" class="iso-8601-duration-field-wrapper" data-duration-fieldname="{{ field.field_name }}">
     <div class="row">
         <div class="col-sm-12">
             <h2>Time precision or spacing</h2>
@@ -123,7 +123,7 @@
     {%
         call form.input(
             field.field_name,
-            id='field-' + field.field_name,
+            id='field-' + field.field_name + '-hidden',
             label=h.scheming_language_text(field.label),
             placeholder=h.scheming_language_text(field.form_placeholder),
             value=data[field.field_name],

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
@@ -15,7 +15,7 @@
 <div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="select">
     <label class="control-label" for="field-{{ field.field_name }}">{{ field.label }}</label>
     {% if errors[field.field_name] and errors[field.field_name] is iterable %}<span class="error-block">{{ errors[field.field_name]|join(', ')|safe }}</span>{% endif %}
-    <div data-repeater-list="{{ field.field_name }}">
+    <div id="{{ 'field-' + field.field_name }}" data-repeater-list="{{ field.field_name }}">
 
         {# Default behaviour to re-populate all existing inputs #}
         {% set group_values = h.get_multi_textarea_values(data[field.field_name])  %}
@@ -62,7 +62,7 @@
 {# BEGIN: The actual form field the multiple values will be captured & submitted in #}
 {% call form.textarea(
     field.field_name,
-    id='field-' + field.field_name,
+    id='field-' + field.field_name + '-hidden',
     label=h.scheming_language_text(field.label),
     value=data[field.field_name],
     classes=ns.field_classes,

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_group.html
@@ -32,7 +32,7 @@
         {% for group_data in group_values or [''] %}
         
             <div data-repeater-item class="repeater-wrapper">
-                <div class="row vertical-align">
+                <div class="row vertical-align{{ ' recommended-field' if field.recommended else '' }}">
                     {% for field_group in field.get('field_group') or [] %}
                         <div class="col-lg-{{ 12 // field.get('field_group')|length }}">
                             {% if field_group.form_snippet %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_markdown.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_markdown.html
@@ -2,7 +2,7 @@
 
 <div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="textarea">
 
-    <div data-repeater-list="{{ field.field_name }}">
+    <div id="{{ 'field-' + field.field_name }}" data-repeater-list="{{ field.field_name }}">
 
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
@@ -38,7 +38,7 @@
 {# BEGIN: The actual form field the multiple values will be captured & submitted in #}
 {% call form.textarea(
     field.field_name,
-    id='field-' + field.field_name,
+    id='field-' + field.field_name + '-hidden',
     label=h.scheming_language_text(field.label),
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_markdown.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_markdown.html
@@ -7,7 +7,7 @@
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
         {% for value in values %}
-        <div data-repeater-item class="row vertical-align">
+        <div data-repeater-item class="row vertical-align{{ ' recommended-field' if field.recommended else '' }}">
             <div class="col-lg-11">
                 {% call form.markdown(
                     label=h.scheming_language_text(field.label),

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_select.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_select.html
@@ -11,7 +11,7 @@
 
         {% for value in values %}
                 
-            <div data-repeater-item class="row vertical-align">
+            <div data-repeater-item class="row vertical-align{{ ' recommended-field' if field.recommended else '' }}">
                 <div class="col-lg-11">              
                     {%- set options=[] -%}
                     {%- set form_restrict_choices_to=field.get('form_restrict_choices_to') -%}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_select.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_select.html
@@ -5,7 +5,7 @@
 
 <div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="select">
 
-    <div data-repeater-list="{{ field.field_name }}">
+    <div id="{{ 'field-' + field.field_name }}" data-repeater-list="{{ field.field_name }}">
 
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
@@ -70,7 +70,7 @@
 {# BEGIN: The actual form field the multiple values will be captured & submitted in #}
 {% call form.textarea(
     field.field_name,
-    id='field-' + field.field_name,
+    id='field-' + field.field_name + '-hidden',
     label=h.scheming_language_text(field.label),
     value=data[field.field_name],
     classes=default_classes + visibility,

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
@@ -16,7 +16,8 @@
                     {% set value = h.dump_json({"id": value, "text":  h.scheming_choices_label(h.scheming_field_choices(field), value)}) %}
                 {% endif %}
             {% endif %}
-            <div data-repeater-item class="row">
+
+            <div data-repeater-item class="row{{ ' recommended-field' if field.recommended else '' }}">
                 <div class="col-xs-11">
                     {%
                         call form.input(
@@ -61,7 +62,7 @@
         label=h.scheming_language_text(field.label),
         placeholder=h.scheming_language_text(field.form_placeholder),
         value=data[field.field_name],
-        classes=default_classes + visibility,
+        classes=default_classes + visibility + ['anjay'],
         is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_text.html
@@ -2,7 +2,7 @@
 
 <div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="input">
 
-    <div data-repeater-list="{{ field.field_name }}">
+    <div id="{{ 'field-' + field.field_name }}" data-repeater-list="{{ field.field_name }}">
 
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
@@ -57,7 +57,7 @@
 {%
     call form.input(
         field.field_name,
-        id='field-' + field.field_name,
+        id='field-' + field.field_name + '-hidden',
         label=h.scheming_language_text(field.label),
         placeholder=h.scheming_language_text(field.form_placeholder),
         value=data[field.field_name],

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_textarea.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_textarea.html
@@ -2,7 +2,7 @@
 
 <div id="{{ field.field_name }}-repeater" class="repeating-field" data-field-type="textarea">
 
-    <div data-repeater-list="{{ field.field_name }}">
+    <div id="{{ 'field-' + field.field_name }}" data-repeater-list="{{ field.field_name }}">
 
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
@@ -38,7 +38,7 @@
 {# BEGIN: The actual form field the multiple values will be captured & submitted in #}
 {% call form.textarea(
     field.field_name,
-    id='field-' + field.field_name,
+    id='field-' + field.field_name + '-hidden',
     label=h.scheming_language_text(field.label),
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],

--- a/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_textarea.html
+++ b/ckanext/qdes_schema/templates/scheming/form_snippets/qdes_multi_textarea.html
@@ -7,7 +7,7 @@
         {% set values = h.get_multi_textarea_values(data[field.field_name]) or [] %}
 
         {% for value in values %}
-        <div data-repeater-item class="row vertical-align">
+        <div data-repeater-item class="row vertical-align{{ ' recommended-field' if field.recommended else '' }}">
             <div class="col-lg-11">
                 {% call form.textarea(
                     label=h.scheming_language_text(field.label),

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -425,11 +425,11 @@ def qdes_validate_metadata_review_date(key, flattened_data, errors, context):
     """
     try:
         extras = flattened_data.get(('__extras',), {}) or None
-        metadata_review_date_reviewed = extras.get('metadata_review_date_reviewed', {}) or None
-        package = context.get('package', {}) or {}
-        type = package.type if package else None
+        metadata_review_date_reviewed = extras.get('metadata_review_date_reviewed', None) if extras else None
+        type = flattened_data.get(('type',))
+        value = flattened_data.get(key)
 
-        if (type in ['dataset', 'dataservice']) and (metadata_review_date_reviewed or len(flattened_data.get(key)) == 0):
+        if (type in ['dataset', 'dataservice']) and (metadata_review_date_reviewed or value is missing or value is None or len(value) == 0):
             # If empty OR checkbox ticked.
             flattened_data[key] = dt.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
     except Exception as e:

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -1,3 +1,4 @@
+import ckan.lib.navl.dictization_functions as df
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 import geojson
@@ -14,6 +15,8 @@ log = logging.getLogger(__name__)
 get_action = logic.get_action
 h = toolkit.h
 Invalid = toolkit.Invalid
+missing = df.missing
+StopOnError = df.StopOnError
 
 
 def qdes_temporal_start_end_date(key, flattened_data, errors, context):
@@ -26,10 +29,21 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
     """
     error = None
 
-    try:
-        temporal_start_value = flattened_data[('temporal_start',)]
-        temporal_end_value = flattened_data[('temporal_end',)]
+    temporal_start_value = flattened_data.get(('temporal_start',), None)
+    if temporal_start_value:
+        split = temporal_start_value.split('T')
+        temporal_start_value = split[0] if len(split) > 1 else temporal_start_value
 
+    temporal_end_value = flattened_data.get(('temporal_end',), None)
+    if temporal_end_value:
+        split = temporal_end_value.split('T')
+        temporal_end_value = split[0] if len(split) > 1 else temporal_end_value
+
+    if (temporal_start_value is missing or temporal_start_value is None) and (temporal_end_value is missing or temporal_end_value is None):
+        flattened_data.pop(key, None)
+        raise StopOnError
+
+    try:
         if ((len(temporal_start_value) > 0) != (len(temporal_end_value) > 0)) and (len(flattened_data.get(key)) == 0):
             error = 'This field should not be empty'
 
@@ -39,6 +53,7 @@ def qdes_temporal_start_end_date(key, flattened_data, errors, context):
                     error = 'Must be earlier than end date.'
                 elif key == ('temporal_end',):
                     error = 'Must be later than start date.'
+
     except Exception as e:
         log.error(str(e), exc_info=True)
 


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-139

- the issue is mostly in multi field, where the id is on the hidden field.
- with `related_resources_multi_group` field, I override the validator as we don't need this field on the external service.. yet.
- also fix small bugs on 
-- https://it-partners.atlassian.net/browse/DDCI-285
-- https://it-partners.atlassian.net/browse/DDCI-350
-- https://it-partners.atlassian.net/browse/DDCI-377
-- https://it-partners.atlassian.net/browse/DDCI-374
-- https://it-partners.atlassian.net/browse/DDCI-299
-- https://it-partners.atlassian.net/browse/DDCI-352
-- https://it-partners.atlassian.net/browse/DDCI-383
-- https://it-partners.atlassian.net/browse/DDCI-384

when I modify `qdes_ckan_dataset.json`, I also made the similar changes to the other scheming json, to make sure those files are in sync, prevent unnecessary work when investigating why those files are different, 

and I apologise for combining many tickets here, I need the previous changes on the other tickets.