### PR TITLE
[PATCH] Chained data services auth overrides.

### DIFF
--- a/ckanext/qdes_schema/auth.py
+++ b/ckanext/qdes_schema/auth.py
@@ -1,51 +1,54 @@
+import ckan.authz as authz
 import ckan.plugins.toolkit as toolkit
 import logging
 
-from ckan.common import g
-from pprint import pformat
-
+_ = toolkit._
 log = logging.getLogger(__name__)
-get_action = toolkit.get_action
-request = toolkit.request
 
 
-def data_service_admin_only(data_dict):
-    if g.userobj:
-        admins = g.userobj.sysadmin or g.userobj.get_groups('organization', 'admin')
+def user_can_manage_dataservices(next_auth, context, data_dict=None):
+    # Use the context['user'] as per CKAN core logic/auth/create.py -> package_create
+    user = context['user']
 
-        if not admins:
-            if g.controller == 'dataservice':
-                return {'success': False}
-            elif data_dict:
-                if data_dict.get('type') == 'dataservice':
-                    return {'success': False}
-                elif data_dict.get('id'):
-                    try:
-                        pkg = get_action('package_show')({}, {'id': data_dict.get('id')})
-                        if pkg.get('type') == 'dataservice':
-                            return {'success': False}
-                    except Exception as e:
-                        log.error(str(e))
+    if not data_dict or not isinstance(data_dict, dict):
+        data_dict = {}
 
+    # We only want our auth function to take effect if we are dealing with a data service
+    # and the user is not an admin of some group - otherwise fall back to default CKAN
+    # auth function
+    package_type = data_dict.get('type')
+
+    if 'dataservice' in [toolkit.get_endpoint()[0], package_type] \
+            and not authz.has_user_permission_for_some_org(user, 'admin'):
+        return {'success': False, 'msg': _('User not authorized to perform action')}
+
+    return next_auth(context, data_dict)
+
+
+@toolkit.chained_auth_function
+def package_create(next_auth, context, data_dict):
+    return user_can_manage_dataservices(next_auth, context, data_dict)
+
+
+@toolkit.chained_auth_function
+def package_update(next_auth, context, data_dict):
+    return user_can_manage_dataservices(next_auth, context, data_dict)
+
+
+@toolkit.chained_auth_function
+def package_patch(next_auth, context, data_dict):
+    return user_can_manage_dataservices(next_auth, context, data_dict)
+
+
+@toolkit.chained_auth_function
+def package_delete(next_auth, context, data_dict):
+    return user_can_manage_dataservices(next_auth, context, data_dict)
+
+
+def dataservice_index(context, data_dict):
+    # Use the context['user'] as per CKAN core logic/auth/create.py -> package_create
+    user = context['user']
+
+    if not authz.has_user_permission_for_some_org(user, 'admin'):
+        return {'success': False, 'msg': _('User not authorized to perform action')}
     return {'success': True}
-
-
-@toolkit.auth_allow_anonymous_access
-def site_read(context, data_dict):
-    return data_service_admin_only(data_dict)
-
-
-def package_create(context, data_dict):
-    return data_service_admin_only(data_dict)
-
-
-def package_update(context, data_dict):
-    return data_service_admin_only(data_dict)
-
-
-def package_patch(context, data_dict):
-    return data_service_admin_only(data_dict)
-
-
-def package_delete(context, data_dict):
-    return data_service_admin_only(data_dict)

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -347,9 +347,9 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     # IAuthFunctions
     def get_auth_functions(self):
         return {
-            'site_read': auth.site_read,
             'package_create': auth.package_create,
             'package_update': auth.package_update,
             'package_patch': auth.package_patch,
             'package_delete': auth.package_delete,
+            'dataservice_index': auth.dataservice_index,
         }


### PR DESCRIPTION
This patch fixes an issue where the `data_service_admin_only` function would let org admin, editor and member users access and manage datasets and data services they did not have permission for.