### PR TITLE
[DDCI-670] Remove `version` field

### DIFF
--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -642,12 +642,6 @@
       "field_name": "owner_org",
       "label": "Organization",
       "preset": "dataset_organization"
-    },
-    {
-      "field_name": "version",
-      "label": "Version",
-      "validators": "ignore_missing unicode package_version_validator",
-      "form_placeholder": "1.0"
     }
   ],
   "resource_fields": [

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/additional_info.html
@@ -80,5 +80,5 @@
     </tbody>
   </table>
 
-  <a href="{{ h.url_for('qdes_schema.dataset_metadata', id=pkg_dict['id']) }}">{{ _('View all metadata') }}</a>
+  <a href="{{ h.url_for('qdes_schema.dataset_metadata', id=pkg_dict['name']) }}">{{ _('View all metadata') }}</a>
 </section>


### PR DESCRIPTION
- Removed `version` field from dataset metadata schema JSON configuration file
- Changed `View all metadata` link to point to dataset name, not CKAN ID.