### PR TITLE
[DDCI-690] Remediation for displaying deleted collection parent

### DIFF
--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -312,7 +312,10 @@ def get_default_map_zoom():
 
 
 def get_package_dict(id):
-    return get_action('package_show')({}, {'id': id})
+    try:
+        return get_action('package_show')({}, {'id': id})
+    except Exception as e:
+        log.error(str(e))
 
 
 def get_invalid_uris(entity_id, pkg_dict):

--- a/ckanext/qdes_schema/logic/helpers/relationship_helpers.py
+++ b/ckanext/qdes_schema/logic/helpers/relationship_helpers.py
@@ -2,7 +2,7 @@ import ckan.plugins.toolkit as toolkit
 import json
 import logging
 
-from ckan.model import PackageRelationship, Session
+from ckan.model import Package, PackageRelationship, Session
 
 log = logging.getLogger(__name__)
 
@@ -97,5 +97,23 @@ def get_existing_relationship(subject_package_id, object_package_id, type):
             .filter(PackageRelationship.object_package_id == object_package_id) \
             .filter(PackageRelationship.type == type) \
             .first()
+    except Exception as e:
+        log.error(str(e))
+
+
+def get_collection_parent_title(pkg_id):
+    """
+    Could use a `package_show` action call with context `ignore_auth` set to True, but
+    unsure what knock-on effect that has, so using a Package query here
+    :param id:
+    :return:
+    """
+    try:
+        collection_parent = Session.query(Package.title, Package.state) \
+            .filter(Package.id == pkg_id) \
+            .first()
+        if collection_parent:
+            suffix = ' [{}]'.format(toolkit._('Deleted')) if collection_parent.state == 'deleted' else ''
+            return '{0}{1}'.format(collection_parent.title, suffix)
     except Exception as e:
         log.error(str(e))

--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -311,6 +311,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'get_published_distributions': helpers.get_published_distributions,
             'get_state_list': helpers.get_state_list,
             'get_pkg_title': helpers.get_pkg_title,
+            'get_collection_parent_title': relationship_helpers.get_collection_parent_title,
         }
 
     def get_multi_textarea_values(self, value):

--- a/ckanext/qdes_schema/templates/snippets/collection.html
+++ b/ckanext/qdes_schema/templates/snippets/collection.html
@@ -14,15 +14,19 @@
     <p>This dataset is part of the following collection:</p>
 
     {% for parent in relationships.get('Is Part Of') %}
-      {% set parent_pkg = h.get_package_dict(parent.pkg_id) %}
       <p>
         <span class="pill small">Collection</span>
-        <a href="{{ h.url_for('dataset_read', id=parent_pkg.id) }}">
-          {{ h.get_pkg_title(parent_pkg.id, parent_pkg) }}
-        </a>
-      </p>
-      <p>
-        {{ parent_pkg.notes|truncate(200) }}
+        {% set parent_pkg = h.get_package_dict(parent.pkg_id) %}
+        {% if parent_pkg %}
+            <a href="{{ h.url_for('dataset_read', id=parent_pkg.id) }}">
+              {{ parent.pkg_title }}
+            </a>
+          </p>
+          <p>
+            {{ parent_pkg.notes|truncate(200) }}
+        {% else %}
+          {{ h.get_collection_parent_title(parent.pkg_id) }}
+        {% endif %}
       </p>
     {% endfor %}
   </div>


### PR DESCRIPTION
- Added `try ... except` to `get_package_dict` helper function to avoid internal server error on exception (e.g. `NotAuthorized`)
- Added new helper method `get_collection_parent_title` to `logic/helpers/relationship_helpers.py`
- Adjusted display of collection(s) snippet in cases where user not authorised to see collection parent dataset