### PR TITLE
feature/DDCI-441-Error-displays-to-a-catalogue-user-when-viewing-a-private-related-dataset

### DIFF
--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -92,7 +92,8 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
         if request and request.endpoint == 'dataset.edit':
             if h.dataset_has_published_to_external_schema(pkg_dict.get('id')):
                 url = h.url_for('qdes_schema.datasets_schema_validation', id=pkg_dict.get('id'))
-                h.flash_success('You have updated a dataset that is publicly available. Please go to the <a href="' + url +'">Publish tab</a> to validate the changes and publish to the relevant data service(s). This will ensure the metadata is updated in all systems.', True)
+                h.flash_success('You have updated a dataset that is publicly available. Please go to the <a href="' + url +
+                                '">Publish tab</a> to validate the changes and publish to the relevant data service(s). This will ensure the metadata is updated in all systems.', True)
 
         return pkg_dict
 
@@ -399,6 +400,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
     # IAuthFunctions
     def get_auth_functions(self):
         return {
+            'package_show': auth.package_show,
             'package_create': auth.package_create,
             'package_update': auth.package_update,
             'package_patch': auth.package_patch,

--- a/ckanext/qdes_schema/templates/snippets/search_form.html
+++ b/ckanext/qdes_schema/templates/snippets/search_form.html
@@ -1,0 +1,27 @@
+{% ckan_extends %}
+
+{% block search_facets %}
+  {% if facets %}
+    <p class="filter-list">
+      {% for field in facets.fields %}
+        {% set search_facets_items = facets.search.get(field)['items'] %}
+        <span class="facet">{{ facets.titles.get(field) }}:</span>
+        {% for value in facets.fields[field] %}
+          <span class="filtered pill">
+            {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
+              {{ facets.translated_fields[(field,value)] }}
+            {%- else -%}
+                {% set display_name = value %}
+                {% if field == 'collection_package_id' %}
+                    {% set display_name = h.get_package_dict(value).get('title', None) %}
+                {%- endif %}
+                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', display_name) }}
+            {%- endif %}
+            <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+          </span>
+        {% endfor %}
+      {% endfor %}
+    </p>
+    <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
[DDCI-441]
- Chained auth 'package_show'
- If the user has no access, return a different abort message if the dataset is private

[DDCI-562]
- Added template override for 'search_form' snippet
- If the field is 'collection_package_id' display the package title
-
@salsa-nathan I accidentally pushed the changes for https://it-partners.atlassian.net/browse/DDCI-562 into this branch.
So this now for [DDCI-441] and [DDCI-562]