### PR TITLE
[DDCI-727] - prevented get_action to raise an exception

### DIFF
--- a/ckanext/qdes_schema/fanstatic/style.css
+++ b/ckanext/qdes_schema/fanstatic/style.css
@@ -8,3 +8,6 @@
     margin-bottom: 10px;
 }
 
+#datasets_available-repeater {
+    display: none;
+}

--- a/ckanext/qdes_schema/logic/action/update.py
+++ b/ckanext/qdes_schema/logic/action/update.py
@@ -63,9 +63,9 @@ def dataservice_datasets_available(context, data):
 
                     # ref.: https://docs.ckan.org/en/2.9/api/#ckan.logic.action.patch.package_update
                     # "You must be authorized to edit the dataset and the groups that it belongs to."
-                    context['ignore_auth'] = True
-                    # package_patch seems to be failing validation here
-                    get_action('package_update')(context, dataservice_dict)
+                    site_user = get_action(u'get_site_user')({u'ignore_auth': True}, {})
+                    ctx = {u'user': site_user[u'name'], 'ignore_auth': True}
+                    get_action('package_update')(ctx, dataservice_dict)
         except Exception as e:
             log.error(str(e))
 

--- a/ckanext/qdes_schema/qdes_dataservice.json
+++ b/ckanext/qdes_schema/qdes_dataservice.json
@@ -101,7 +101,7 @@
       "field_name": "datasets_available",
       "label": "Datasets available",
       "display_snippet": "qdes_multi_text_url.html",
-      "form_snippet": null,
+      "form_snippet": "qdes_multi_text.html",
       "display_group": null
     },
     {

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
@@ -76,7 +76,7 @@
               </button>
               <div class="collapsing-section" id="display-group-{{field.display_group}}-content">
         {%- endif -%}
-      {%- else -%} 
+      {%- else -%}
         {%- if field.display_group not in ['general'] -%}
           <h2>{{ field.display_group|capitalize }}</h2>
         {%- endif -%}
@@ -100,6 +100,8 @@
         </article>
       </section>
     {%- endif -%}
+
+
   {%- endfor -%}
   {%- if 'resource_fields' not in schema -%}
     <!-- force controller to skip resource-editing step for this type -->


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-727
https://it-partners.atlassian.net/browse/DDCI-728

so the issue is `data-qld` dataservive has missing dataset that will fail the validation (via API or via get_action)
https://ckan.develop.qdes-ckan.au2.amazee.io/api/3/action/package_show?id=data-qld
`
"related_resources": "[{\"resource\": {\"id\": \"a6a8668f-f6e9-4682-9c2c-1c1a75627057\", \"text\": \"QSpatial\"}, \"relationship\": \"unspecified relationship\"}, {\"resource\": {\"id\": \"26989519-a87e-4778-b630-62b3d0ac951d\", \"text\": \"Data Service - DDCI-392 - Service A [Deleted]\"}, \"relationship\": \"Is Format Of\"}]",
`

re-saving the data-qld via ui will fix the issue or remove manually via API request. you maybe want to clean that before smoke test it

in this PR I also updated dataservice json schema, it was not visible on the form, and when doing re-save the datasets_available value just gone, to hide them I use css

so the question is, how the missing dataset can be in there, I believe this will raise an issue in future.