### PR TITLE
feature/DDCI-441-Error-displays-to-a-catalogue-user-when-viewing-a-private-related-dataset

### DIFF
--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -749,7 +749,7 @@ def get_state_list(field=None):
 def get_pkg_title(name_or_id, pkg_dict=[]):
     try:
         if not pkg_dict:
-            pkg_dict = get_action('package_show')({}, {'name_or_id': name_or_id})
+            pkg_dict = get_action('package_show')({'ignore_auth': True}, {'name_or_id': name_or_id})
 
         pkg_name = h.dataset_display_name(pkg_dict)
 

--- a/ckanext/qdes_schema/logic/action/get.py
+++ b/ckanext/qdes_schema/logic/action/get.py
@@ -103,7 +103,7 @@ def build_versions(tree):
     versions = []
     for version in tree:
         try:
-            package_dict = get_action('package_show')({}, {'id': version.get('object')})
+            package_dict = get_action('package_show')({'ignore_auth': True}, {'id': version.get('object')})
             versions.append(package_dict)
         except Exception as e:
             log.error(str(e))


### PR DESCRIPTION
- Added `ignore_auth` property to context for `build_versions` and `get_pkg_title`
    - User does not need access to dataset to display the information required eg. private datasets for versions and dataset titles